### PR TITLE
Patch 1

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -146,8 +146,8 @@
         },
         "kombu": {
             "hashes": [
-                "sha256:52763f41077e25fe7e2f17b8319d8a7b7ab953a888c49d9e4e0464fceb716896",
-                "sha256:9bf7d37b93249b76a03afb7bbcf7149a358b6079ca2431e725414b1caa10922c"
+                "sha256:1ef049243aa05f29e988ab33444ec7f514375540eaa8e0b2e1f5255e81c5e56d",
+                "sha256:3c9dca2338c5d893f30c151f5d29bfb81196748ab426d33c362ab51f1e8dbf78"            
             ],
             "version": "==4.2.2.post1"
         },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -149,7 +149,7 @@
                 "sha256:52763f41077e25fe7e2f17b8319d8a7b7ab953a888c49d9e4e0464fceb716896",
                 "sha256:9bf7d37b93249b76a03afb7bbcf7149a358b6079ca2431e725414b1caa10922c"
             ],
-            "version": "==4.2.2"
+            "version": "==4.2.2.post1"
         },
         "psycopg2-binary": {
             "hashes": [


### PR DESCRIPTION

kombu 4.2.2 isn't on pypi anymore  …
Using version 4.2.2.post1 seems to be our best bet at the moment.
mozilla/addons-server#10282