### PR TITLE
Ajoute l'import quotidien des données de l'Ademe

### DIFF
--- a/deployment/roles/appservers/tasks/cron.yml
+++ b/deployment/roles/appservers/tasks/cron.yml
@@ -14,3 +14,11 @@
     minute: "44"
     hour: "7"
     job: "cd {{ django_root }} && source {{ activate_bin }} && {{ pipenv_bin }} run ./manage.py reviewable_aids_alert --settings={{ django_settings }}"
+
+- name: Install the daily ademe data import task
+  cron:
+    name: Import data from the ademe's feed
+    user: "{{ user_name }}"
+    minute: "42"
+    hour: "2"
+    job: "cd {{ django_root }} && source {{ activate_bin }} && {{ pipenv_bin }} run ./manage.py import_ademe --settings={{ django_settings }}"


### PR DESCRIPTION
Mise à jour du script de déploiement avec l'ajout d'une tâche quotidienne pour importer les données de l'ademe.

https://trello.com/c/zGEz6kV1/207-activer-limport-ademe-hebdomadairement