### PR TITLE
Alertes pour les nouvelles aides

### DIFF
--- a/src/aids/management/commands/new_aids_alert.py
+++ b/src/aids/management/commands/new_aids_alert.py
@@ -15,7 +15,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         yesterday = timezone.now() - timedelta(days=1)
         new_aids = Aid.objects \
-            .published() \
             .filter(date_created__gte=yesterday) \
             .order_by('author') \
             .select_related('author')


### PR DESCRIPTION
Au lieu d'envoyer une alerte pour les aides publiées la veille, considérer *toutes* les aides (même celles en brouillon).