### PR TITLE
Center "Congratulations!"

### DIFF
--- a/src/templates/accounts/login_success.html
+++ b/src/templates/accounts/login_success.html
@@ -8,10 +8,8 @@
 {% block content %}
 <div class="narrow-form">
     <h1>{{ _("You are now logged in") }}</h1>
-    <center>
-    <p>{% blocktrans trimmed %}
+    <p class="center">{% blocktrans trimmed %}
         Congratulations!
     {% endblocktrans %}</p>
-    </center>
 </div>
 {% endblock %}

--- a/src/templates/accounts/login_success.html
+++ b/src/templates/accounts/login_success.html
@@ -8,8 +8,10 @@
 {% block content %}
 <div class="narrow-form">
     <h1>{{ _("You are now logged in") }}</h1>
+    <center>
     <p>{% blocktrans trimmed %}
         Congratulations!
     {% endblocktrans %}</p>
+    </center>
 </div>
 {% endblock %}


### PR DESCRIPTION
Lors de la création de compte, le "félicitations" n'est pas centré par rapport au texte " vous êtes désormais contributeur" (ou équivalent)
=> à centrer si possible
https://trello.com/c/wV1lQRL3