### PR TITLE
Supprime le filtre « aides récentes seulement »

### DIFF
--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -137,14 +137,6 @@ class AidSearchForm(forms.Form):
         required=False,
         widget=forms.TextInput(
             attrs={'placeholder': _('Aid title, keyword, etc.')}))
-    # We use a multiple choice field so the filter rendering remains
-    # consistent with the other filters
-    recent_only = forms.MultipleChoiceField(
-        label=_('Recent aids'),
-        choices=(
-            (_('Yes'), _('Only display aids created less than 30 days ago')),),
-        required=False,
-        widget=MultipleChoiceFilterWidget)
     apply_before = forms.DateField(
         label=_('Apply before…'),
         required=False,
@@ -219,11 +211,6 @@ class AidSearchForm(forms.Form):
         apply_before = self.cleaned_data.get('apply_before', None)
         if apply_before:
             qs = qs.filter(submission_deadline__lt=apply_before)
-
-        recent_only = self.cleaned_data.get('recent_only', False)
-        if recent_only:
-            a_month_ago = timezone.now() - timedelta(days=30)
-            qs = qs.filter(date_created__gte=a_month_ago.date())
 
         call_for_projects_only = self.cleaned_data.get(
             'call_for_projects_only', False)

--- a/src/aids/tests/test_search_engine.py
+++ b/src/aids/tests/test_search_engine.py
@@ -378,21 +378,6 @@ def test_full_text_advanced_syntax(client, perimeters):
     assert res.context['paginator'].count == 1
 
 
-def test_the_only_recent_filter(client, perimeters, aids):
-    """Display ALL the aids."""
-
-    url = reverse('search_view')
-    res = client.get(url, data={'recent_only': 'Oui '})
-    assert res.context['paginator'].count == 105
-
-    long_ago = timezone.now() - timedelta(days=50)
-    for aid in aids[:5]:
-        aid.date_created = long_ago
-        aid.save()
-    res = client.get(url, data={'recent_only': 'Oui'})
-    assert res.context['paginator'].count == 100
-
-
 def test_the_call_for_project_only_filter(client, perimeters, aids):
 
     for aid in aids[:5]:

--- a/src/templates/aids/_search_form.html
+++ b/src/templates/aids/_search_form.html
@@ -39,7 +39,6 @@
                 {% include '_field_snippet.html' with field=form.perimeter %}
                 {% include '_field_snippet.html' with field=form.destinations %}
                 {% include '_field_snippet.html' with field=form.mobilization_step %}
-                {% include '_field_snippet.html' with field=form.recent_only %}
                 {% include '_field_snippet.html' with field=form.apply_before %}
             </div>
         </div>

--- a/src/templates/aids/advanced_search.html
+++ b/src/templates/aids/advanced_search.html
@@ -27,7 +27,6 @@
         {% include '_field_snippet.html' with field=form.scale %}
         {% include '_field_snippet.html' with field=form.destinations %}
         {% include '_field_snippet.html' with field=form.mobilization_step %}
-        {% include '_field_snippet.html' with field=form.recent_only %}
         {% include '_field_snippet.html' with field=form.order_by %}
         <button type="submit">
             {{ _('Find aids') }}


### PR DESCRIPTION
https://trello.com/c/Mi7lLC7B/282-enlever-la-coche-aides-ajout%C3%A9es-au-cours-des-30-derniers-jours-dans-la-recherche-avanc%C3%A9e