### PR TITLE
Corrige l'autocomplétion des tags en admin

### DIFF
--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -107,7 +107,10 @@ class AidAdminForm(BaseAidForm):
     """Custom Aid edition admin form."""
 
     class Media:
-        js = ['admin/js/tags_autocomplete.js']
+        js = [
+            'admin/js/jquery.init.js',
+            'admin/js/tags_autocomplete.js'
+        ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
https://trello.com/c/swxC9OhP/252-probl%C3%A8me-sur-le-remplissage-de-fiche-champ-mot-cl%C3%A9

Bug provoqué par le passage à django 2.2.
https://docs.djangoproject.com/en/dev/releases/2.2/#merging-of-form-media-assets