### PR TITLE
Affichage correct de la section « origine de la donnée »

### DIFF
--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -1,11 +1,9 @@
 import re
 import operator
-from datetime import timedelta
 
 from django import forms
 from django.db.models import Q, F
 from django.utils.translation import ugettext_lazy as _
-from django.utils import timezone
 from django.contrib.postgres.search import SearchQuery, SearchRank
 
 from core.forms.widgets import (AutocompleteSelectMultiple,

--- a/src/dataproviders/management/commands/import_grand_est.py
+++ b/src/dataproviders/management/commands/import_grand_est.py
@@ -37,6 +37,9 @@ class Command(CrawlerImportCommand):
     def extract_import_data_url(self, line):
         return line['current_url']
 
+    def extract_origin_url(self, line):
+        return line['current_url']
+
     def extract_import_share_licence(self, line):
         return Aid.IMPORT_LICENCES.unknown
 

--- a/src/dataproviders/scrapers/grand_est.py
+++ b/src/dataproviders/scrapers/grand_est.py
@@ -23,8 +23,7 @@ class GrandEstSpider(scrapy.Spider):
         links = response.css('a.card')
         for link in links:
             link_url = link.css('::attr("href")').get()
-            absolute_url = self.BASE_URL + link_url
-            request = scrapy.Request(absolute_url, callback=self.aid_parse)
+            request = scrapy.Request(link_url, callback=self.aid_parse)
 
             card_header = link.css('div.txt.new_txt span.new_type::text').get()
             if 'Date limite de dépôt' in card_header:

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -182,9 +182,9 @@
             {% endblocktrans %}</p>
             <dl>
                 <dt>{{ _('Origin url') }}</dt>
-                <dd>{{ aid.import_data_url }}</dd>
+                <dd>{{ aid.import_data_url|default_if_none:_('NA') }}</dd>
                 <dt>{{ _('Import share license') }}</dt>
-                <dd>{{ aid.get_import_share_licence_display }}</dd>
+                <dd>{{ aid.get_import_share_licence_display|default:_('NA') }}</dd>
                 <dt>{{ _('Last data access') }}</dt>
                 <dd>{{ aid.import_last_access|date }}</dd>
             </dl>


### PR DESCRIPTION
La section « origine de la donnée » (page de détail des aides) s'affichait de manière incorrecte (affichage de « None » et de valeurs vides).

J'ai ajouté des valeurs par défaut.

J'en ai profité pour corriger quelques tâches d'imports qui n'étaient plus fonctionnelles.

https://trello.com/c/eqfXhDVC/269-v%C3%A9rifier-laffichage-de-la-section-origine-de-la-donn%C3%A9e