### PR TITLE
Corrige le problème de rendu pour les long périmètres

### DIFF
--- a/src/static/css/custom.scss
+++ b/src/static/css/custom.scss
@@ -64,6 +64,7 @@ section#contribute {
 
             div.search-control {
                 flex-grow: 1;
+                min-width: 0;
                 margin-bottom: 0;
 
                 .select2-selection {
@@ -73,6 +74,7 @@ section#contribute {
             }
 
             button {
+                white-space: nowrap;
                 @include border-left-radius(0);
                 width: inherit;
             }


### PR DESCRIPTION
Ex : sur la page d'accueil, faire une recherche sur « Marseille ».