### PR TITLE
Corrige la redirection après le login

### DIFF
--- a/src/templates/_anonymous_menu.html
+++ b/src/templates/_anonymous_menu.html
@@ -9,6 +9,7 @@
             <h6 id="profile-menu">{{ _('Log in to access your account') }}</h6>
             <form method="post" action="{% url 'login' %}">
                 {% csrf_token %}
+                <input type="hidden" name="next" value="{{ request.get_full_path }}" />
 
                 <div class="form-group">
                     <label for="id_username">{{ _('Your email address') }}</label>


### PR DESCRIPTION
Après la connexion, redirige l'utilisateur vers la page courante.

https://trello.com/c/mPsoD0mI/391-changer-la-redirection-lors-de-la-connexion-sur-at

Puisque nous utilisons la [vue django standard](https://docs.djangoproject.com/fr/2.2/topics/auth/default/#django.contrib.auth.views.LoginView) pour le login, c'est aussi simple que d'ajouter un champ caché « next ».