### PR TITLE
Corrige un problème de mise en page sur petits écrans

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -427,9 +427,9 @@
       }
     },
     "bootstrap": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
-      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
+      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/src/package.json
+++ b/src/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.10.2",
     "autoprefixer": "^9.6.1",
-    "bootstrap": "^4.3.1",
+    "bootstrap": "^4.4.1",
     "jquery": "^3.4.1",
     "postcss-cli": "^6.1.3",
     "select2": "^4.0.10",

--- a/src/static/css/styles.scss
+++ b/src/static/css/styles.scss
@@ -204,7 +204,7 @@ nav#main-navbar {
 
 main {
     section.main-content {
-        @extend .container;
+        @extend .container-lg;
         @extend .py-4;
 
         a.main-action,


### PR DESCRIPTION
Utilise les [nouveaux *responsive containers*](https://getbootstrap.com/docs/4.4/layout/overview/#containers) disponibles dans la nouvelle version de Bootstrap pour maximiser la taille du layout sur les petits écrans.