### PR TITLE
chore: upgrade nodejs

### DIFF
--- a/deployment/roles/appservers/tasks/packages.yml
+++ b/deployment/roles/appservers/tasks/packages.yml
@@ -14,7 +14,7 @@
 
 - name: Add nodesource apt repository to install NodeJs
   apt_repository:
-    repo: deb https://deb.nodesource.com/node_8.x stretch main
+    repo: deb https://deb.nodesource.com/node_12.x stretch main
     state: present
     filename: nodesource
 


### PR DESCRIPTION
Nodejs 8 is obsolete: https://nodejs.org/en/about/releases/