### PR TITLE
fix missing .bashrc file during ansible deployment

### DIFF
--- a/deployment/roles/appservers/tasks/user.yml
+++ b/deployment/roles/appservers/tasks/user.yml
@@ -18,6 +18,14 @@
     setfacl -m {{ user_name }}:rwx "$SSH_AUTH_SOCK"
   changed_when: false
 
+- name: "Ensure .bashrc file exists in `{{ user_name }}` home root"
+  file:
+    path: "{{ install_root }}/.bashrc"
+    owner: "{{ user_name }}"
+    group: "{{ user_name }}"
+    state: touch
+  changed_when: False
+
 - name: Make sure the django settings module env is set
   lineinfile:
     path: "{{ install_root }}/.bashrc"


### PR DESCRIPTION
Fixes Issue #161

Ajout d'une tache supplémentaire avant écriture dans le fichier `.bashrc` afin de s'assurer que le fichier existe bien.

La propriété `changed_when` permet de terminer la tache en statut `ok` si le fichier existe déjà. 
En effet le module `file` exécuté avec `state: touch` semble renvoyer systématiquement le statut `changed`.

https://github.com/ansible/ansible/issues/30226#issuecomment-328952676

