### PR TITLE
Ajoute une indication d'url canonique sur les minisites

### DIFF
--- a/src/minisites/views.py
+++ b/src/minisites/views.py
@@ -71,12 +71,18 @@ class MinisiteMixin:
         return obj
 
     def get_context_data(self, **kwargs):
+
+        # Canonical url definition
+        # E.g we want to mark `aides.francemobilites.fr` as a duplicate of
+        # `francemobilites.aides-territoires.beta.gouv.fr`.
+        main_site_domain = Site.objects.get_current().domain
+        page_subdomain = self.search_page.slug
+        canonical_url = f'https://{page_subdomain}.{main_site_domain}'
+
         context = super().get_context_data(**kwargs)
         context['search_page'] = self.search_page
         context['site_url'] = self.request.build_absolute_uri('').rstrip('/')
-        context['canonical_url'] = 'https://{}.{}/'.format(
-            self.search_page.slug,
-            Site.objects.get_current().domain)
+        context['canonical_url'] = canonical_url
 
         return context
 

--- a/src/minisites/views.py
+++ b/src/minisites/views.py
@@ -74,6 +74,10 @@ class MinisiteMixin:
         context = super().get_context_data(**kwargs)
         context['search_page'] = self.search_page
         context['site_url'] = self.request.build_absolute_uri('').rstrip('/')
+        context['canonical_url'] = 'https://{}.{}/'.format(
+            self.search_page.slug,
+            Site.objects.get_current().domain)
+
         return context
 
 

--- a/src/templates/minisites/search_page.html
+++ b/src/templates/minisites/search_page.html
@@ -13,6 +13,8 @@
 {% if search_page.meta_image %}
 <meta property="og:image" content="{{ site_url }}{{ search_page.meta_image.url }}" />
 {% endif %}
+
+ <link rel="canonical" href="{{ canonical_url }}" />
 {% endblock %}
 
 {% block header %}


### PR DESCRIPTION
https://trello.com/c/JBhUSFn7/617-ajouter-les-indications-durl-canoniques-entre-les-diff%C3%A9rents-sites

Les pages de recherche pouvant exister derrière plusieurs domaines sont dé-doublonnées au moyen d'une indication d'url canonique.