### PR TITLE
add SIB-LIST-ID to .env.example

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -9,3 +9,4 @@ GOAL_REGISTER_ID=1
 GOAL_FIRST_LOGIN_ID=2
 MAILING_LIST_URL=https://sibforms.com/serve/TODO
 SIB_API_KEY='dummy-key'
+SIB_LIST_ID=24


### PR DESCRIPTION
Ajout du paramètre `SIB_LIST_ID=24` au fichier `.env.example` afin d'éviter une erreur lors de la commande `ansible-playbook -i hosts -l local site.yml`
