### PR TITLE
correct h1 after bg-color

### DIFF
--- a/src/static/css/_globals.scss
+++ b/src/static/css/_globals.scss
@@ -594,6 +594,7 @@ h1 {
     &::after {
         content: "";
         color: transparent;
+        background-color: #DB1C83;
         display: block;
         width: 6rem;
         height: 0px;

--- a/src/templates/minisites/_css.html
+++ b/src/templates/minisites/_css.html
@@ -139,6 +139,7 @@ section#aid-list article div span.deadline-delta {
 
 h1::after {
     border-color: {{ search_page.color_3 }};
+    background-color: {{ search_page.color_3 }};
 }
 
 article#aid .card > div::before {


### PR DESCRIPTION
Correction d'un bug d'affichage des h1 after (au zoom ou dezoom apparition d'un espace vide dans la barre de soulignement). 