### PR TITLE
Minisites : corrige des erreurs d'affichage

### DIFF
--- a/src/templates/minisites/_css.html
+++ b/src/templates/minisites/_css.html
@@ -88,17 +88,19 @@ button[type=submit] {
     border: {{ search_page.color_3 }} !important;
 }
 
-section#search-engine div.form-container button:hover,
-section#search-engine a#save-alert-btn:hover,
-div#share-results-modal form button:hover,
-div.modal .modal-dialog section footer button:hover,
-.cta-btn:hover,
-.btn-primary:hover,
-button[type=submit]:hover {
-    background-color: {% darken search_page.color_3 15 %} !important;
-    color: white !important;
-    text-decoration: none !important;
-}
+{% if search_page.color_3 %}
+    section#search-engine div.form-container button:hover,
+    section#search-engine a#save-alert-btn:hover,
+    div#share-results-modal form button:hover,
+    div.modal .modal-dialog section footer button:hover,
+    .cta-btn:hover,
+    .btn-primary:hover,
+    button[type=submit]:hover {
+        background-color: {% darken search_page.color_3 15 %} !important;
+        color: white !important;
+        text-decoration: none !important;
+    }
+{% endif %}
 
 a#publish-new-aids-btn[href^="http"]::after {
     display: none;
@@ -177,11 +179,13 @@ ol.breadcrumb li.active {
     text-decoration: underline;
 }
 
-.dark-background .main-content > article a:hover,
-section#aid-list article.aid div h1 a:hover,
-a:hover {
-    color: {% darken search_page.color_4 20 %} !important;
-}
+{% if search_page.color_4 %}
+    .dark-background .main-content > article a:hover,
+    section#aid-list article.aid div h1 a:hover,
+    a:hover {
+        color: {% darken search_page.color_4 20 %} !important;
+    }
+{% endif %}
 
 body > footer {
     background-color: {{ search_page.color_5 }} !important;

--- a/src/templates/minisites/_footer.html
+++ b/src/templates/minisites/_footer.html
@@ -13,9 +13,11 @@
                 <img class="logo" id="logo-fabnum" src="/static/img/logo-fabriquenumerique.svg" alt="Logo de la Fabrique Numérique" />
             </a>
     
-            <a class="partner-link" href="{{ search_page.logo_link }}">
-                <img class="logo" src="{{ search_page.logo.url }}" alt="Logo : {{ search_page.title }}"/>
-            </a>
+            {% if search_page.logo %}
+                <a class="partner-link" href="{{ search_page.logo_link }}">
+                    <img class="logo" src="{{ search_page.logo.url }}" alt="Logo : {{ search_page.title }}"/>
+                </a>
+            {% endif %}
         </div>
     </div>
     <div class="other_links_nav">

--- a/src/templates/minisites/_header.html
+++ b/src/templates/minisites/_header.html
@@ -4,11 +4,13 @@
         <div class="logo_RF">
             <img src="/static/img/logo_RP.svg" alt="Logo Marianne" />
         </div>
-       
+
         <div class="logos_partners">
-            <a class="partner-link" href="{{ search_page.logo_link }}">
-                <img class="logo" src="{{ search_page.logo.url }}" alt="Logo : {{ search_page.title }}"/>
-            </a>
+            {% if search_page.logo %}
+                <a class="partner-link" href="{{ search_page.logo_link }}">
+                    <img class="logo" src="{{ search_page.logo.url }}" alt="Logo : {{ search_page.title }}"/>
+                </a>
+            {% endif %}
             <a href="https://aides-territoires.beta.gouv.fr" title="Aides-territoires">
                 <img class="logo" src="/static/img/logo_AT_courbes.svg" alt="Logo d'Aides-territoires" />
             </a>


### PR DESCRIPTION
Correction de deux erreurs concernants les minisites : 
- la page plantait si les champs `color_3` ou `color_4` étaient vides
- la page plantait si le champs `logo` était vide
