### PR TITLE
Fix des typos et rajoute de l'écriture inclusive

### DIFF
--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -2106,7 +2106,7 @@ msgstr ""
 "revue par un administrateur."
 
 msgid "Save and request publication"
-msgstr "Enregister et demander la publication"
+msgstr "Enregistrer et demander la publication"
 
 msgid "Save as a draft"
 msgstr "Enregistrer en brouillon"

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -176,7 +176,7 @@ msgid "Author"
 msgstr "Auteur"
 
 msgid "Backers"
-msgstr "Porteurs d'aides"
+msgstr "Porteur.s d'aides"
 
 msgid "Perimeter"
 msgstr "Périmètre"
@@ -206,10 +206,10 @@ msgid "Misc data"
 msgstr "Données diverses"
 
 msgid "Financers"
-msgstr "Financeurs"
+msgstr "Porteur.s d’aides"
 
 msgid "Instructors"
-msgstr "Instructeurs"
+msgstr "Instructeur.s"
 
 msgid "Live"
 msgstr "Live"
@@ -366,10 +366,10 @@ msgid "Aid title"
 msgstr "Nom de l'aide"
 
 msgid "Aid backer(s)"
-msgstr "Porteur(s) de l'aide"
+msgstr "Porteur.s de l'aide"
 
 msgid "Aid instructor(s)"
-msgstr "Instructeur(s) de l'aide"
+msgstr "Instructeur.s de l'aide"
 
 msgid "…or add a new financer"
 msgstr "…ou ajoutez un nouveau financeur"
@@ -727,7 +727,7 @@ msgid "Who is submitting the aid?"
 msgstr "Qui renseigne cette aide ?"
 
 msgid "Financer suggestion"
-msgstr "Financeurs suggérés"
+msgstr "Porteurs d'aides suggérés"
 
 msgid "Project examples"
 msgstr "Exemples de projets réalisables"
@@ -1477,7 +1477,7 @@ msgid "Log out"
 msgstr "Déconnexion"
 
 msgid "Aid backers"
-msgstr "Porteurs d'aides"
+msgstr "Porteur.s d'aides"
 
 msgid "Login now and publish your aids."
 msgstr "Connectez-vous et diffusez vos aides dès maintenant !"

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -176,7 +176,7 @@ msgid "Author"
 msgstr "Auteur"
 
 msgid "Backers"
-msgstr "Porteur.s d'aides"
+msgstr "Porteur·s d'aides"
 
 msgid "Perimeter"
 msgstr "Périmètre"
@@ -206,10 +206,10 @@ msgid "Misc data"
 msgstr "Données diverses"
 
 msgid "Financers"
-msgstr "Porteur.s d’aides"
+msgstr "Porteur·s d’aides"
 
 msgid "Instructors"
-msgstr "Instructeur.s"
+msgstr "Instructeur·s"
 
 msgid "Live"
 msgstr "Live"
@@ -351,7 +351,7 @@ msgid "Other eligibility criterias?"
 msgstr "Conditions d'éligibilité"
 
 msgid "Contact to apply"
-msgstr "Contact(s) pour candidater"
+msgstr "Contact·s pour candidater"
 
 msgid "Feel free to add several contacts"
 msgstr "N'hésitez pas à ajouter plusieurs contacts"
@@ -366,13 +366,13 @@ msgid "Aid title"
 msgstr "Nom de l'aide"
 
 msgid "Aid backer(s)"
-msgstr "Porteur.s de l'aide"
+msgstr "Porteur·s de l'aide"
 
 msgid "Aid instructor(s)"
-msgstr "Instructeur.s de l'aide"
+msgstr "Instructeur·s de l'aide"
 
 msgid "…or add a new financer"
-msgstr "…ou ajoutez un nouveau financeur"
+msgstr "…ou ajoutez un nouveau porteur d'aide"
 
 msgid "Types of expenses covered"
 msgstr "Types de dépenses / actions couvertes"
@@ -396,7 +396,7 @@ msgstr ""
 "vous pouvez utiliser ce champ pour nous le communiquer."
 
 msgid "Please provide a financer, or suggest a new one."
-msgstr "Merci d'indiquer un financeur."
+msgstr "Merci d'indiquer un porteur d'aide."
 
 msgid "Please indicate the maximum subvention rate."
 msgstr "Merci d'indiquer le taux de subvention maximum."
@@ -415,7 +415,7 @@ msgid ""
 "with the field above."
 msgstr ""
 "Ce porteur a été suggéré. Créez le nouvel apporteur et ajouter le en tant "
-"que financeur via le champ approprié."
+"que porteur d'aides via le champ approprié."
 
 msgid "Instructor suggestion"
 msgstr "Instructeurs suggérés"
@@ -1477,7 +1477,7 @@ msgid "Log out"
 msgstr "Déconnexion"
 
 msgid "Aid backers"
-msgstr "Porteur.s d'aides"
+msgstr "Porteur·s d'aides"
 
 msgid "Login now and publish your aids."
 msgstr "Connectez-vous et diffusez vos aides dès maintenant !"
@@ -1518,15 +1518,15 @@ msgstr "Votre ville, intercommunalité, département…"
 msgid "Type a few characters to see some suggestions."
 msgstr "Saisissez quelques caractères pour des suggestions."
 
-msgid "Choose backers(s) among the list."
-msgstr "Sélectionnez le(s) porteur(s) parmi la liste."
+msgid "Choose backer(s) among the list."
+msgstr "Sélectionnez le·s porteur·s parmi la liste."
 
 msgid "Choose instructor(s) among the list."
-msgstr "Sélectionnez le(s) instructeur(s) parmi la liste."
+msgstr "Sélectionnez le·s instructeur·s parmi la liste."
 
 msgctxt "js_catalog"
 msgid "What kind of aids are you looking for?"
-msgstr "Quel(s) type(s) d\\'aide cherchez-vous ?"
+msgstr "Quel·s type·s d\\'aide cherchez-vous ?"
 
 msgctxt "js_catalog"
 msgid "When to mobilize the aid?"

--- a/src/templates/_anonymous_menu.html
+++ b/src/templates/_anonymous_menu.html
@@ -7,7 +7,7 @@
     </li>
     <li>
         <a href="/porteurs-aides/">
-            Porteurs d'aides
+            Porteur·s d'aides
         </a>
     </li>
     <li>

--- a/src/templates/_js_i18n.html
+++ b/src/templates/_js_i18n.html
@@ -8,7 +8,7 @@ var catalog = {
     autocomplete_placeholder: '{{ _("Type a few characters to see some suggestions.") }}',
     tags_placeholder: '{{ _("Type a few characters to see some suggestions.") }}',
     autocomplete_placeholder: '{{ _("Type a few characters to see some suggestions.") }}',
-    financers_placeholder: '{{ _("Choose backers(s) among the list.") }}',
+    financers_placeholder: '{{ _("Choose backer(s) among the list.") }}',
     instructors_placeholder: '{{ _("Choose instructor(s) among the list.") }}',
     aid_types_placeholder: '{% trans "What kind of aids are you looking for?" context 'js_catalog' %}',
     mobilization_steps_placeholder: '{% trans "When to mobilize the aid?" context 'js_catalog' %}',

--- a/src/templates/data/doc.html
+++ b/src/templates/data/doc.html
@@ -105,12 +105,12 @@ sur le site est accessible à cette adresse.</a></p>
         <tr>
             <td>financers</td>
             <td>array</td>
-            <td>La liste des noms des financeurs de l'aide</td>
+            <td>La liste des noms des porteurs de l'aide</td>
         </tr>
         <tr>
             <td>instructors</td>
             <td>array</td>
-            <td>La liste des noms des instructeurs de l'aide (si différente des financeurs)</td>
+            <td>La liste des noms des instructeurs de l'aide (si différente des porteurs)</td>
         </tr>
         <tr>
             <td>description</td>
@@ -130,7 +130,7 @@ sur le site est accessible à cette adresse.</a></p>
         <tr>
             <td>perimeter</td>
             <td>string</td>
-            <td>Description du périmètre géographique sur lequel l'aide s'applique </td>
+            <td>Description du périmètre géographique sur lequel l'aide s'applique</td>
         </tr>
         <tr>
             <td>mobilization_steps</td>
@@ -150,17 +150,17 @@ sur le site est accessible à cette adresse.</a></p>
         <tr>
             <td>targeted_audiences</td>
             <td>array</td>
-            <td>Public(s) concerné(s) par l'aide</td>
+            <td>Public·s concerné·s par l'aide</td>
         </tr>
         <tr>
             <td>aid_types</td>
             <td>array</td>
-            <td>Précision sur le(s) type(s) d'aide (financière ou non)</td>
+            <td>Précision sur le·s type·s d'aide (financière ou non)</td>
         </tr>
         <tr>
             <td>destinations</td>
             <td>array</td>
-            <td>Précision sur le(s) type(s) d'action(s) soutenue(s) par l'aide </td>
+            <td>Précision sur le·s type·s d'action·s soutenue·s par l'aide</td>
         </tr>
         <tr>
             <td>start_date</td>
@@ -195,12 +195,12 @@ sur le site est accessible à cette adresse.</a></p>
         <tr>
             <td>recurrence</td>
             <td>string</td>
-            <td>Précision sur le caractère ponctuel, récurrent, permanent de l'aide </td>
+            <td>Précision sur le caractère ponctuel, récurrent, permanent de l'aide</td>
         </tr>
         <tr>
             <td>project_examples</td>
             <td>text (html)</td>
-            <td>Exemples de projets ayant déjà bénéficié de cette aide </td>
+            <td>Exemples de projets ayant déjà bénéficié de cette aide</td>
         </tr>
         <tr>
             <td>date_created</td>


### PR DESCRIPTION
Modifications apportées : 
- Ajout de l'écriture inclusive
  - `Porteurs d'aides` --> `Porteur·s d'aides`
  - `Contact(s)` --> `Contact·s`
  - etc.
- Remplacement de "financeur" par "porteur d'aides"
- typos
  - `Enregister` --> `Enregistrer`