### PR TITLE
update max-width partner-link-img

### DIFF
--- a/src/templates/minisites/_css.html
+++ b/src/templates/minisites/_css.html
@@ -55,7 +55,7 @@ body > #partner-navbar .container-lg > .logos_partners > a[href^="http"]::after 
 }
 
 body > #partner-navbar .container-lg > .logos_partners a img {
-    height: 120px;
+    max-height: 120px;
     width: auto;
 }
 

--- a/src/templates/minisites/_css.html
+++ b/src/templates/minisites/_css.html
@@ -59,6 +59,10 @@ body > #partner-navbar .container-lg > .logos_partners a img {
     width: auto;
 }
 
+body > #partner-navbar .partner-link img {
+    max-width: 20rem;
+}
+
 .dark-background .main-content > article,
 .dark-background .main-content > div.article,
 section#aid-list article,
@@ -317,6 +321,10 @@ body > footer nav ul li a[href^="http"]:hover::after {
 @media screen and (min-width: 600px) {
     body > #partner-navbar .container-lg > .logos_partners {
         flex-direction: row;
+    }
+
+    body > #partner-navbar .partner-link img {
+        max-width: 35rem;
     }
 
     body > #partner-navbar .container-lg > .logos_partners a {


### PR DESCRIPTION
Changement de la max-width du logo partenaire dans le header des PP afin d'éviter l'anamorphose des doubles logos (ex: arc de l'innovation Paris&co). 