### PR TITLE
Amélioration de l'upload de périmètres

### DIFF
--- a/src/geofr/admin_views.py
+++ b/src/geofr/admin_views.py
@@ -41,13 +41,15 @@ class PerimeterUpload(MessageMixin, SingleObjectMixin, FormView):
         if perimeter_type == 'city_code':
             # Fetch the list of commune perimeters from the uploaded file
             # The list should be error-free (cleaned in PerimeterUploadForm)
-            city_codes = extract_perimeters_from_file(form.cleaned_data['city_code_list'])  # noqa
+            city_codes = extract_perimeters_from_file(
+                form.cleaned_data['city_code_list'])
             attach_perimeters(current_perimeter, city_codes)
 
         elif perimeter_type == 'epci_name':
             # Fetch the list of EPCI perimeters from the uploaded file
             # The list should be error-free (cleaned in PerimeterUploadForm)
-            epci_names = extract_perimeters_from_file(form.cleaned_data['epci_name_list'])  # noqa
+            epci_names = extract_perimeters_from_file(
+                form.cleaned_data['epci_name_list'])
             attach_epci_perimeters(current_perimeter, epci_names)
 
         msg = format_html(
@@ -55,7 +57,9 @@ class PerimeterUpload(MessageMixin, SingleObjectMixin, FormView):
             name=_('Perimeter'),
             obj=format_html(
                 '<a href="{obj_url}">{obj_name}</a>',
-                obj_url=reverse('admin:geofr_perimeter_change', args=[current_perimeter.id]),  # noqa
+                obj_url=reverse(
+                    'admin:geofr_perimeter_change', args=[current_perimeter.id]
+                ),
                 obj_name=current_perimeter
             )
         )

--- a/src/geofr/forms/forms.py
+++ b/src/geofr/forms/forms.py
@@ -1,6 +1,8 @@
 from django import forms
+from django.core.exceptions import ValidationError
 from django.contrib import admin
 from django.contrib.admin.widgets import AutocompleteSelectMultiple
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 # from core.forms import AutocompleteSelectMultiple
@@ -8,9 +10,43 @@ from geofr.models import Perimeter
 
 
 class PerimeterUploadForm(forms.Form):
-    city_list = forms.FileField(
-        label=_('City list'),
-        required=True)
+    city_code_list = forms.FileField(
+        label=_('City list (insee codes)'),
+        required=True
+    )
+
+    def clean_city_code_list(self):
+        city_code_list_file = self.cleaned_data['city_code_list']
+
+        # get all city_codes
+        city_codes = []
+        for line in city_code_list_file:
+            try:
+                code = line.decode().strip().split(';')[0]
+                clean_code = str(code)
+                city_codes.append(clean_code)
+            except (UnicodeDecodeError, ValueError) as e:
+                msg = _('This file seems invalid. \
+                        Please double-check its content or contact the \
+                        dev team if you feel like it\'s an error. \
+                        Here is the original error: {}').format(e)
+                raise ValidationError(msg)
+
+        # check these city_codes exist
+        perimeters = Perimeter.objects \
+            .filter(code__in=city_codes) \
+            .filter(scale=Perimeter.TYPES.commune) \
+            .values_list('code', flat=True)
+
+        # raise an error if there are unknown city_codes
+        missing_city_codes = list(set(city_codes) - set(perimeters))
+        if len(missing_city_codes):
+            raise ValidationError(mark_safe(
+                _('List of missing city codes:') + "<br />"
+                + "<br />".join(missing_city_codes))
+            )
+
+        return city_code_list_file
 
 
 class PerimeterCombineForm(forms.Form):

--- a/src/geofr/forms/forms.py
+++ b/src/geofr/forms/forms.py
@@ -7,46 +7,88 @@ from django.utils.translation import ugettext_lazy as _
 
 # from core.forms import AutocompleteSelectMultiple
 from geofr.models import Perimeter
+from geofr.utils import (extract_perimeters_from_file,
+                         query_cities_from_list, query_epcis_from_list)
 
 
 class PerimeterUploadForm(forms.Form):
+    PERIMETER_TYPE_CHOICES = (
+        ('city_code', _('City list (insee codes)')),
+        ('epci_name', _('EPCI list (names)')),
+    )
+
+    perimeter_type = forms.ChoiceField(
+        label=_('Perimeter type'),
+        required=True,
+        choices=PERIMETER_TYPE_CHOICES
+    )
     city_code_list = forms.FileField(
         label=_('City list (insee codes)'),
-        required=True
+        required=False
     )
+    epci_name_list = forms.FileField(
+        label=('EPCI list (names)'),
+        required=False
+    )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        perimeter_type = cleaned_data.get("perimeter_type")
+        city_code_list = cleaned_data.get("city_code_list")
+        epci_name_list = cleaned_data.get("epci_name_list")
+
+        if perimeter_type == 'city_code' and not self.has_error('city_code_list') and not city_code_list:  # noqa
+            self.add_error('city_code_list', 'File missing')
+        elif perimeter_type == 'epci_name' and not self.has_error('epci_name_list') and not epci_name_list:  # noqa
+            self.add_error('epci_name_list', 'File missing')
 
     def clean_city_code_list(self):
         city_code_list_file = self.cleaned_data['city_code_list']
 
-        # get all city_codes
-        city_codes = []
-        for line in city_code_list_file:
+        if city_code_list_file:
+            # get all city_codes
             try:
-                code = line.decode().strip().split(';')[0]
-                clean_code = str(code)
-                city_codes.append(clean_code)
-            except (UnicodeDecodeError, ValueError) as e:
-                msg = _('This file seems invalid. \
-                        Please double-check its content or contact the \
-                        dev team if you feel like it\'s an error. \
-                        Here is the original error: {}').format(e)
-                raise ValidationError(msg)
+                city_codes = extract_perimeters_from_file(city_code_list_file)
+            except Exception as e:
+                raise ValidationError(e)
 
-        # check these city_codes exist
-        perimeters = Perimeter.objects \
-            .filter(code__in=city_codes) \
-            .filter(scale=Perimeter.TYPES.commune) \
-            .values_list('code', flat=True)
+            # check these city_codes exist
+            perimeters = query_cities_from_list(city_codes) \
+                .values_list('code', flat=True)
 
-        # raise an error if there are unknown city_codes
-        missing_city_codes = list(set(city_codes) - set(perimeters))
-        if len(missing_city_codes):
-            raise ValidationError(mark_safe(
-                _('List of missing city codes:') + "<br />"
-                + "<br />".join(missing_city_codes))
-            )
+            # raise an error if there are unknown city_codes
+            missing_city_codes = list(set(city_codes) - set(perimeters))
+            if len(missing_city_codes):
+                raise ValidationError(mark_safe(
+                    _('List of missing city codes:') + "<br />"
+                    + "<br />".join(missing_city_codes))
+                )
 
         return city_code_list_file
+
+    def clean_epci_name_list(self):
+        epci_name_list_file = self.cleaned_data['epci_name_list']
+
+        if epci_name_list_file:
+            # get all epci_names
+            try:
+                epci_names = extract_perimeters_from_file(epci_name_list_file)
+            except Exception as e:
+                raise ValidationError(e)
+
+            # check these epci_names exist
+            perimeters = query_epcis_from_list(epci_names) \
+                .values_list('name', flat=True)
+
+            # raise an error if there are unknown epci_names
+            missing_epci_names = list(set(epci_names) - set(perimeters))
+            if len(missing_epci_names):
+                raise ValidationError(mark_safe(
+                    _('List of missing EPCI names:') + "<br />"
+                    + "<br />".join(missing_epci_names))
+                )
+
+        return epci_name_list_file
 
 
 class PerimeterCombineForm(forms.Form):

--- a/src/geofr/tests/test_utils.py
+++ b/src/geofr/tests/test_utils.py
@@ -45,7 +45,7 @@ def test_attach_perimeters(perimeters):
 
 
 def test_attach_perimeters_cleans_old_data(perimeters):
-    """Attaching perimeters to a city list removes all other attachments."""
+    """Attaching perimeters to a city code list removes all other attachments."""
 
     adhoc = PerimeterFactory(
         name='Communes littorales',

--- a/src/geofr/utils.py
+++ b/src/geofr/utils.py
@@ -1,3 +1,5 @@
+import collections
+
 from django.db import transaction
 from django.utils.translation import ugettext_lazy as _
 
@@ -30,6 +32,8 @@ def is_overseas(zipcode):
 
 def extract_perimeters_from_file(perimeter_list_file):
     item_list = []
+
+    # extract items
     for line in perimeter_list_file:
         try:
             item = line.decode().strip().split(';')[0]
@@ -41,6 +45,14 @@ def extract_perimeters_from_file(perimeter_list_file):
                     dev team if you feel like it\'s an error. \
                     Here is the original error: {}').format(e)
             raise Exception(msg)
+
+    # check for duplicates
+    duplicates = [item for item, count in collections.Counter(item_list).items() if count > 1]  # noqa
+    if len(duplicates):
+        msg = _('This file is valid, but contains \
+                duplicates: {}').format(duplicates)
+        raise Exception(msg)
+
     return item_list
 
 

--- a/src/geofr/utils.py
+++ b/src/geofr/utils.py
@@ -47,7 +47,8 @@ def extract_perimeters_from_file(perimeter_list_file):
             raise Exception(msg)
 
     # check for duplicates
-    duplicates = [item for item, count in collections.Counter(item_list).items() if count > 1]  # noqa
+    duplicates = [item for item, count in
+                  collections.Counter(item_list).items() if count > 1]
     if len(duplicates):
         msg = _('This file is valid, but contains \
                 duplicates: {}').format(duplicates)

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -1168,14 +1168,20 @@ msgstr ""
 "qu'il s'agit d'une erreur, contactez l'équipe de développement. Voici "
 "l'erreur d'origine : {}"
 
+msgid "List of missing city codes:"
+msgstr "Liste des codes insee des communes manquants :"
+
 msgid "We successfully updated the perimeters."
 msgstr "Le périmètre a bien été mis à jour."
+
+msgid "The {name} “{obj}” was changed successfully."
+msgstr "L’objet {name} « {obj} » a été modifié avec succès."
 
 msgid "We successfully configured the perimeter."
 msgstr "Le périmètre a bien été configuré."
 
-msgid "City list"
-msgstr "Liste de communes"
+msgid "City list (insee codes)"
+msgstr "Liste de communes (codes insee)"
 
 msgid "Perimeters to add"
 msgstr "Périmètres à additionner"
@@ -1906,7 +1912,7 @@ msgid "Combine perimeters"
 msgstr "Combiner des périmètres"
 
 msgid "Upload city list"
-msgstr "Télécharger la liste des communes"
+msgstr "Uploader la liste des communes"
 
 #, python-format
 msgid " By %(filter_title)s "
@@ -1929,7 +1935,7 @@ msgid "Submit"
 msgstr "Envoyer"
 
 msgid "Upload"
-msgstr "Télécharger"
+msgstr "Uploader"
 
 msgid ""
 "Use this form to upload the list of cities contained in the selected <em>ad-"

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-02 15:30+0100\n"
+"POT-Creation-Date: 2020-11-05 15:43+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1044,6 +1044,11 @@ msgstr "Apporteur privé ?"
 msgid "Backer"
 msgstr "Apporteur"
 
+#, fuzzy
+#| msgid "How often do you want to receive alerts?"
+msgid "How often to you want to receive alerts?"
+msgstr "À quelle fréquence souhaitez-vous recevoir les nouveaux résultats ?"
+
 msgid "Receive new results by email"
 msgstr "Recevoir les nouveaux résultats par e-mail"
 
@@ -1159,21 +1164,7 @@ msgstr "Upload de périmètre"
 msgid "Perimeter combine"
 msgstr "Combinaison de périmètre"
 
-msgid ""
-"This file seems invalid.                         Please double-check its "
-"content or contact the                         dev team if you feel like "
-"it's an error.                         Here is the original error: {}"
-msgstr ""
-"Ce fichier semble invalide ; merci de vérifier son contenu. Si vous pensez "
-"qu'il s'agit d'une erreur, contactez l'équipe de développement. Voici "
-"l'erreur d'origine : {}"
-
-msgid "List of missing city codes:"
-msgstr "Liste des codes insee des communes manquants :"
-
-msgid "We successfully updated the perimeters."
-msgstr "Le périmètre a bien été mis à jour."
-
+#, python-brace-format
 msgid "The {name} “{obj}” was changed successfully."
 msgstr "L’objet {name} « {obj} » a été modifié avec succès."
 
@@ -1182,6 +1173,18 @@ msgstr "Le périmètre a bien été configuré."
 
 msgid "City list (insee codes)"
 msgstr "Liste de communes (codes insee)"
+
+msgid "EPCI list (names)"
+msgstr "Liste d'EPCIs (noms)"
+
+msgid "Perimeter type"
+msgstr "Type de périmètre"
+
+msgid "List of missing city codes:"
+msgstr "Liste des codes insee des communes manquants :"
+
+msgid "List of missing EPCI names:"
+msgstr "Liste des noms des EPCIs manquants :"
 
 msgid "Perimeters to add"
 msgstr "Périmètres à additionner"
@@ -1233,6 +1236,20 @@ msgstr "En Outre-mer ?"
 
 msgid "Perimeters"
 msgstr "Périmètres"
+
+#, fuzzy
+#| msgid ""
+#| "This file seems invalid.                         Please double-check its "
+#| "content or contact the                         dev team if you feel like "
+#| "it's an error.                         Here is the original error: {}"
+msgid ""
+"This file seems invalid.                     Please double-check its content "
+"or contact the                     dev team if you feel like it's an "
+"error.                     Here is the original error: {}"
+msgstr ""
+"Ce fichier semble invalide ; merci de vérifier son contenu. Si vous pensez "
+"qu'il s'agit d'une erreur, contactez l'équipe de développement. Voici "
+"l'erreur d'origine : {}"
 
 msgid "Structure"
 msgstr "Structure"
@@ -1911,8 +1928,8 @@ msgstr "Ne contient pas d'autres périmètres"
 msgid "Combine perimeters"
 msgstr "Combiner des périmètres"
 
-msgid "Upload city list"
-msgstr "Uploader la liste des communes"
+msgid "Upload perimeter list"
+msgstr "Uploader la liste des périmètres"
 
 #, python-format
 msgid " By %(filter_title)s "
@@ -1938,13 +1955,20 @@ msgid "Upload"
 msgstr "Uploader"
 
 msgid ""
-"Use this form to upload the list of cities contained in the selected <em>ad-"
-"hoc</em> perimeter. The file must be a list of insee codes (one per line) "
-"for french cities."
+"Use this form to upload the list of cities or EPCIs contained in the "
+"selected <em>ad-hoc</em> perimeter.<br /> - For cities: the file must be a "
+"list of insee codes (one per line) for french cities<br /> - For EPCIs: the "
+"file must of a list of EPCI names (one per line)"
 msgstr ""
-"Utilisez ce formulaire pour spécifier la liste des communes contenues dans "
-"le périmètre <em>ad-hoc</em>. Le fichier doit contenir les codes insee (un "
-"par ligne) des communes."
+"Utilisez ce formulaire pour spécifier la liste des communes ou EPCIs "
+"contenues dans le périmètre <em>ad-hoc</em>.<br />- Communes : le fichier "
+"doit contenir les codes insee (un par ligne) des communes<br />- EPCIs : le "
+"fichier doit contenir le nom (un par ligne) des EPCIs"
+
+#, fuzzy
+#| msgid "For:"
+msgid "or"
+msgstr "Pour :"
 
 msgid "Send file"
 msgstr "Envoyer le fichier"

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-05 15:43+0100\n"
+"POT-Creation-Date: 2020-11-05 17:07+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1044,8 +1044,6 @@ msgstr "Apporteur privé ?"
 msgid "Backer"
 msgstr "Apporteur"
 
-#, fuzzy
-#| msgid "How often do you want to receive alerts?"
 msgid "How often to you want to receive alerts?"
 msgstr "À quelle fréquence souhaitez-vous recevoir les nouveaux résultats ?"
 
@@ -1237,11 +1235,6 @@ msgstr "En Outre-mer ?"
 msgid "Perimeters"
 msgstr "Périmètres"
 
-#, fuzzy
-#| msgid ""
-#| "This file seems invalid.                         Please double-check its "
-#| "content or contact the                         dev team if you feel like "
-#| "it's an error.                         Here is the original error: {}"
 msgid ""
 "This file seems invalid.                     Please double-check its content "
 "or contact the                     dev team if you feel like it's an "
@@ -1250,6 +1243,9 @@ msgstr ""
 "Ce fichier semble invalide ; merci de vérifier son contenu. Si vous pensez "
 "qu'il s'agit d'une erreur, contactez l'équipe de développement. Voici "
 "l'erreur d'origine : {}"
+
+msgid "This file is valid, but contains                 duplicates: {}"
+msgstr "Ce fichier est valide, mais comporte des doublons: {}"
 
 msgid "Structure"
 msgstr "Structure"
@@ -1965,10 +1961,8 @@ msgstr ""
 "doit contenir les codes insee (un par ligne) des communes<br />- EPCIs : le "
 "fichier doit contenir le nom (un par ligne) des EPCIs"
 
-#, fuzzy
-#| msgid "For:"
 msgid "or"
-msgstr "Pour :"
+msgstr "ou"
 
 msgid "Send file"
 msgstr "Envoyer le fichier"

--- a/src/templates/admin/geofr/perimeter/submit_line.html
+++ b/src/templates/admin/geofr/perimeter/submit_line.html
@@ -6,7 +6,7 @@
             {{ _('Combine perimeters') }}
         </a>
         <a href="{% url 'admin:geofr_perimeter_upload' original.pk %}" class="submitlink">
-            {{ _('Upload city list') }}
+            {{ _('Upload perimeter list') }}
         </a>
     {% endif %}
     {{ block.super }}

--- a/src/templates/admin/perimeter_combine.html
+++ b/src/templates/admin/perimeter_combine.html
@@ -35,7 +35,7 @@
             {% endfor %}
         </div>
         <div class="submit-row">
-            <input class="default" type="submit" name="{{ _('Submit') }}" />
+            <input class="default" type="submit" name="_save" value="{{ _('Submit') }}" />
         </div>
     </div>
 </form>

--- a/src/templates/admin/perimeter_upload.html
+++ b/src/templates/admin/perimeter_upload.html
@@ -19,9 +19,9 @@
     {% csrf_token %}
     <div>
         <p>{% blocktrans trimmed %}
-            Use this form to upload the list of cities contained
-            in the selected <em>ad-hoc</em> perimeter. The file must
-            be a list of insee codes (one per line) for french cities.
+            Use this form to upload the list of cities or EPCIs contained in the selected <em>ad-hoc</em> perimeter.<br />
+            - For cities: the file must be a list of insee codes (one per line) for french cities<br />
+            - For EPCIs: the file must of a list of EPCI names (one per line)
         {% endblocktrans %}</p>
 
         {% if form.errors %}
@@ -30,10 +30,14 @@
 
         <fieldset class="module aligned">
             <div class="form-row">
-                <div>
-                    {{ form.city_code_list.label_tag }}
-                    {{ form.city_code_list }}
-                </div>
+                <div>{{ form.perimeter_type.label_tag }}{{ form.perimeter_type }}</div>
+            </div>
+            <div class="form-row">
+                <div>{{ form.city_code_list.label_tag }}{{ form.city_code_list }}</div>
+                <br />
+                <div><i>{{ _('or') }}</i></div>
+                <br />
+                <div>{{ form.epci_name_list.label_tag }}{{ form.epci_name_list }}</div>
             </div>
         </fieldset>
         <div class="submit-row">

--- a/src/templates/admin/perimeter_upload.html
+++ b/src/templates/admin/perimeter_upload.html
@@ -24,16 +24,20 @@
             be a list of insee codes (one per line) for french cities.
         {% endblocktrans %}</p>
 
+        {% if form.errors %}
+            {{ form.errors }}
+        {% endif %}
+
         <fieldset class="module aligned">
             <div class="form-row">
                 <div>
-                    {{ form.city_list.label_tag }}
-                    {{ form.city_list }}
+                    {{ form.city_code_list.label_tag }}
+                    {{ form.city_code_list }}
                 </div>
             </div>
         </fieldset>
         <div class="submit-row">
-            <input class="default" type="submit" name="{{ _('Send file') }}" />
+            <input class="default" type="submit" name="_save" value="{{ _('Send file') }}" />
         </div>
     </div>
 </form>


### PR DESCRIPTION
Modifications apportées :
- rajout d'une option d'import d'une liste d'EPCI. Il y a donc maintenant 2 options: une liste de communes (code INSEE), ou une liste d'EPCI (noms)
- les messages d'erreurs sont plus claires
- renvoi d'erreurs si des communes (ou EPCIs) fournies dans la liste sont absents de la base de donnée

Le workflow reste le même : 
1. créer un périmètre (ou sélectionner un périmètre ad-hoc existant)
2. cliquer sur le bouton "Uploader la liste des périmètres" en bas
3. le formulaire d'import apparait
4. si le formulaire ne renvoie pas d'erreurs, le périmètre est mis à jour

étape 3 du workflow : le formulaire d'import, qui a été enrichi
<img width="695" alt="Screenshot 2020-11-05 at 16 11 56" src="https://user-images.githubusercontent.com/7147385/98259092-f36a3c00-1f81-11eb-94e1-931a6cb9638d.png">
