### PR TITLE
Améliorations pour l'import et l'export dans l'admin

### DIFF
--- a/src/accounts/tests/test_views.py
+++ b/src/accounts/tests/test_views.py
@@ -128,7 +128,7 @@ def test_register_form_expects_valid_data(client):
         register_url,
         {'full_name': 'Petit Pifou', 'email': 'tartiflette'})
     assert res.status_code == 200
-    assert 'Saisissez une adresse email valable.' in res.content.decode()
+    assert ' vérifier votre saisie ' in res.content.decode()
 
 
 def test_register_form_with_unique_email(client, user, mailoutbox):

--- a/src/aids/admin.py
+++ b/src/aids/admin.py
@@ -187,7 +187,7 @@ class BaseAidAdmin(ExportActionMixin, admin.ModelAdmin):
     ordering = ['-id']
     save_as = True
     actions = ExportActionMixin.actions + ['make_mark_as_CFP']
-    formats = [base_formats.CSV, base_formats.XLS, base_formats.XLSX]
+    formats = [base_formats.CSV, base_formats.XLSX]
     list_display = [
         'live_status', 'name', 'all_financers', 'all_instructors',
         'author_name', 'recurrence', 'date_updated', 'date_published',

--- a/src/backers/admin.py
+++ b/src/backers/admin.py
@@ -18,14 +18,14 @@ class BackerResource(resources.ModelResource):
         skip_unchanged = True
         # name must be unique
         import_id_fields = ('name',)
-        fields = ('name', 'is_corporate',)
+        fields = ('name',)
 
 
 class BackerAdmin(ImportMixin, admin.ModelAdmin):
     """Admin module for aid backers."""
 
     resource_class = BackerResource
-    formats = [base_formats.CSV, base_formats.XLS, base_formats.XLSX]
+    formats = [base_formats.CSV, base_formats.XLSX]
     list_display = ['name', 'slug', 'is_corporate', 'nb_financed_aids',
                     'nb_instructed_aids']
     search_fields = ['name']


### PR DESCRIPTION
Suite aux tests de https://github.com/MTES-MCT/aides-territoires/pull/228 & https://github.com/MTES-MCT/aides-territoires/pull/230

Import de porteurs d'aides : 
- enlever le champ `is_corporate`
- enlever le format XLS

Export d'aides : 
- enlever le format XLS