### PR TITLE
Export : aides séléctionnées dans l'admin : fix

### DIFF
--- a/src/aids/admin.py
+++ b/src/aids/admin.py
@@ -149,7 +149,7 @@ class AidResource(resources.ModelResource):
                 value = getattr(obj, f'get_{field.column_name}_display')()
                 return field.widget.render(value, obj)
             # ChoiceArrayField fields: need to translate a list
-            elif hasattr(field_model, 'base_field'):
+            elif hasattr(field_model, 'base_field') and field_model.base_field.choices:  # noqa
                 value_raw = field.get_value(obj)
                 if value_raw:
                     # translate each dict choice


### PR DESCRIPTION
Dans la continuité de https://github.com/MTES-MCT/aides-territoires/pull/227 & https://github.com/MTES-MCT/aides-territoires/pull/230

Répare un bug sur l'export : les aides avec un subvention_rate provoquaient une erreur au moment de l'export