### PR TITLE
add minisites FrRel Guyane, Normandie, cvl, grand-est

### DIFF
--- a/deployment/group_vars/prod.yml
+++ b/deployment/group_vars/prod.yml
@@ -16,6 +16,10 @@ certbot_domains:
  - "france-relance-paca.{{ project_domain }}"
  - "france-relance-hdf.{{ project_domain }}"
  - "france-relance-pdl.{{ project_domain }}"
+ - "france-relance-normandie.{{ project_domain }}"
+ - "france-relance-grand-est.{{ project_domain }}"
+ - "france-relance-cvl.{{ project_domain }}"
+ - "france-relance-guyane.{{ project_domain }}"
 
 django_settings: core.settings.production
 minisites_settings: minisites.settings.production


### PR DESCRIPTION
Ajout des sous-domaines : 

- france-relance-normandie
- france-relance-grand-est
- france-relance-cvl
- france-relance-guyane