### PR TITLE
use input instead of label to pass to matomo

### DIFF
--- a/src/static/js/search/track_category_step_events.js
+++ b/src/static/js/search/track_category_step_events.js
@@ -6,7 +6,7 @@
             try {
                 var allCategories = $(this).find('input[type=checkbox]');
 
-                var inputs = $(this).find(':checked').map(function (counter, checkbox) {
+                var inputs = $(this).find(':checked').map(function () {
                     return $(this).val().trim();
                 });
                 var allInputs = inputs.toArray().reduce(function (acc, value) {

--- a/src/static/js/search/track_category_step_events.js
+++ b/src/static/js/search/track_category_step_events.js
@@ -7,8 +7,8 @@
                 var allCategories = $(this).find('input[type=checkbox]');
 
                 var labels = $(this).find(':checked').map(function (counter, checkbox) {
-                    var label = form.find('label[for=' + checkbox.id + '].custom-control-label');
-                    return label.text().trim();
+                    var label = form.find('input[id='+ checkbox.id + '][name=categories].custom-control-input');
+                    return label.val().trim();
                 });
                 var allLabels = labels.toArray().reduce(function (acc, value) {
                     var accumulated;

--- a/src/static/js/search/track_category_step_events.js
+++ b/src/static/js/search/track_category_step_events.js
@@ -6,11 +6,11 @@
             try {
                 var allCategories = $(this).find('input[type=checkbox]');
 
-                var labels = $(this).find(':checked').map(function (counter, checkbox) {
-                    var label = form.find('input[id='+ checkbox.id + '][name=categories].custom-control-input');
-                    return label.val().trim();
+                var inputs = $(this).find(':checked').map(function (counter, checkbox) {
+                    var input = form.find('input[id='+ checkbox.id + '][name=categories].custom-control-input');
+                    return input.val().trim();
                 });
-                var allLabels = labels.toArray().reduce(function (acc, value) {
+                var allInputs = inputs.toArray().reduce(function (acc, value) {
                     var accumulated;
                     if (acc == '') {
                         accumulated = value;
@@ -20,7 +20,7 @@
                     return accumulated;
                 }, '');
                 if (_paq) {
-                    _paq.push(['trackEvent', 'Recherche', stepName, allLabels, allCategories.length]);
+                    _paq.push(['trackEvent', 'Recherche', stepName, allInputs, allCategories.length]);
                 }
             } catch (e) {
                 console.log(e);

--- a/src/static/js/search/track_category_step_events.js
+++ b/src/static/js/search/track_category_step_events.js
@@ -7,8 +7,7 @@
                 var allCategories = $(this).find('input[type=checkbox]');
 
                 var inputs = $(this).find(':checked').map(function (counter, checkbox) {
-                    var input = form.find('input[id='+ checkbox.id + '][name=categories].custom-control-input');
-                    return input.val().trim();
+                    return $(this).val().trim();
                 });
                 var allInputs = inputs.toArray().reduce(function (acc, value) {
                     var accumulated;

--- a/src/static/js/search/track_theme_step_events.js
+++ b/src/static/js/search/track_theme_step_events.js
@@ -4,9 +4,8 @@
     exports.trackSearchEvent = function (form, stepName) {
         form.submit(function () {
             try {
-                var inputs = $(this).find(':checked').map(function (counter, checkbox) {
-                    var input = form.find('input[id='+ checkbox.id + '][name=themes].custom-control-input');
-                    return input.val().trim();
+                var inputs = $(this).find(':checked').map(function () {
+                    return $(this).val().trim();
                 });
                 var allInputs = inputs.toArray().reduce(function (acc, value) {
                     var accumulated;

--- a/src/static/js/search/track_theme_step_events.js
+++ b/src/static/js/search/track_theme_step_events.js
@@ -4,11 +4,11 @@
     exports.trackSearchEvent = function (form, stepName) {
         form.submit(function () {
             try {
-                var labels = $(this).find(':checked').map(function (counter, checkbox) {
-                    var label = form.find('input[id='+ checkbox.id + '][name=themes].custom-control-input');
-                    return label.val().trim();
+                var inputs = $(this).find(':checked').map(function (counter, checkbox) {
+                    var input = form.find('input[id='+ checkbox.id + '][name=themes].custom-control-input');
+                    return input.val().trim();
                 });
-                var allLabels = labels.toArray().reduce(function (acc, value) {
+                var allInputs = inputs.toArray().reduce(function (acc, value) {
                     var accumulated;
                     if (acc == '') {
                         accumulated = value;
@@ -18,7 +18,7 @@
                     return accumulated;
                 }, '');
                 if (_paq) {
-                    _paq.push(['trackEvent', 'Recherche', stepName, allLabels]);
+                    _paq.push(['trackEvent', 'Recherche', stepName, allInputs]);
                 }
             } catch (e) {
                 console.log(e);

--- a/src/static/js/search/track_theme_step_events.js
+++ b/src/static/js/search/track_theme_step_events.js
@@ -5,8 +5,8 @@
         form.submit(function () {
             try {
                 var labels = $(this).find(':checked').map(function (counter, checkbox) {
-                    var label = form.find('label[for=' + checkbox.id + '].custom-control-label');
-                    return label.text().trim();
+                    var label = form.find('input[id='+ checkbox.id + '][name=themes].custom-control-input');
+                    return label.val().trim();
                 });
                 var allLabels = labels.toArray().reduce(function (acc, value) {
                     var accumulated;


### PR DESCRIPTION
Utilise la value de l'input plutôt que le texte du label pour transmettre les thèmes et catégories sélectionnés à Matomo. 

Cela permet de transmettre à Matomo le nom du thème ou de la catégorie sans le nombre variable de résultats associé à ce thème ou à cette catégorie. 

[ticket trello relevant le problème](https://trello.com/c/oilbk1sV/762-donn%C3%A9es-matomo-erron%C3%A9es)