### PR TITLE
Pouvoir chercher par email dans Admin > Alerts

### DIFF
--- a/src/alerts/admin.py
+++ b/src/alerts/admin.py
@@ -8,6 +8,7 @@ class AlertAdmin(admin.ModelAdmin):
         'email', 'title', 'latest_alert_date', 'date_created', 'validated',
         'date_validated'
     ]
+    search_fields = ['email']
     list_filter = ['validated']
 
 


### PR DESCRIPTION
Actuellement il est impossible de retrouver facilement une alerte.
Cette PR rajoute un search par email en haut.