### PR TITLE
add matomo-track-files to compress js file

### DIFF
--- a/src/templates/search/step_audience.html
+++ b/src/templates/search/step_audience.html
@@ -1,4 +1,5 @@
 {% extends '_base.html' %}
+{% load compress %}
 
 {% block extratitle %}{{ _('Search – Audience') }}{% endblock %}
 
@@ -54,5 +55,7 @@
 {% endblock %}
 
 {% block extra_js %}
+{% compress js %}
 <script src="/static/js/search/track_audience_step_events.js"></script>
+{% endcompress %}
 {% endblock %}

--- a/src/templates/search/step_category.html
+++ b/src/templates/search/step_category.html
@@ -1,5 +1,6 @@
 {% extends '_base.html' %}
 {% load i18n %}
+{% load compress %}
 
 {% block extratitle %}{{ _('Search – Categories') }}{% endblock %}
 
@@ -72,5 +73,7 @@
 {% endblock %}
 
 {% block extra_js %}
+{% compress js %}
 <script src="/static/js/search/track_category_step_events.js"></script>
+{% endcompress %}
 {% endblock %}

--- a/src/templates/search/step_theme.html
+++ b/src/templates/search/step_theme.html
@@ -1,4 +1,5 @@
 {% extends '_base.html' %}
+{% load compress %}
 
 {% block extratitle %}{{ _('Search – Theme') }}{% endblock %}
 
@@ -66,5 +67,7 @@
 {% endblock %}
 
 {% block extra_js %}
+{% compress js %}
 <script src="/static/js/search/track_theme_step_events.js"></script>
+{% endcompress %}
 {% endblock %}


### PR DESCRIPTION
Ajout des fichiers `track_category_step_events.js` , `track_theme_step_events.js` , et `track_audience_step_events.js` au fichier js global compressé. 

Cela résoud un souci d'absence de mise à jour des fichiers js gardés abusivement en cache par le navigateur. 