### PR TITLE
fix typo footer

### DIFF
--- a/src/templates/_footer.html
+++ b/src/templates/_footer.html
@@ -5,8 +5,8 @@
                 <a href="https://www.ecologique-solidaire.gouv.fr/" title="Ministère de la Transition écologique">
                     <img class="logo ministry-logo" src="/static/img/logo_mte.svg" alt="Logo du Ministère de la Transition écologique" />
                 </a>
-                <a href="https://www.ecologique-solidaire.gouv.fr/" title="Ministère de la Transition écologique">
-                    <img class="logo ministry-logo" src="/static/img/logo_mct.svg" alt="Logo du Ministère de la Transition écologique" />
+                <a href="https://www.cohesion-territoires.gouv.fr/" title="Ministère de la Cohésion des Territoires et des Relations avec les Collectivités Territoriales">
+                    <img class="logo ministry-logo" src="/static/img/logo_mct.svg" alt="Logo du Ministère de la Cohésion des Territoires et des Relations avec les Collectivités Territoriales" />
                 </a>
             </div>
 

--- a/src/templates/minisites/_footer.html
+++ b/src/templates/minisites/_footer.html
@@ -31,7 +31,7 @@
                     <li><a href="https://aides-territoires.beta.gouv.fr/comptes/profil-contributeur/?next=/aides/publications/">Publier des aides</a></li>
                     <li><a href="https://aides-territoires.beta.gouv.fr/data/">Données et API</a></li>
                     <li><a href="mailto:{{ contact_email }}">{{ contact_email }}</a></li>
-                    <li><a href="tel:07 56 99 59 72">{{ contact_phone }}</a> </li>
+                    <li><a href="tel:{{ contact_phone }}">{{ contact_phone | phone }}</a> </li>
                     <li><a href="https://aides-territoires.beta.gouv.fr/mentions-légales/">Mentions Légales</a></li>
                     <li><a href="https://github.com/MTES-MCT/aides-territoires" title="Ouvrir « https://github.com/MTES-MCT/aides-territoires » dans une nouvelle fenêtre">Code Source</a></li>
                 </ul>


### PR DESCRIPTION
Correction de typo dans le footer d'Aides-territoires et dans celui des sous-domaines : 
- ajout du bon lien pour le logo du Ministère de la Cohésion
- modification du format du téléphone dans le footer des pages personnalisées. 