### PR TITLE
Ajustements cosmétiques sur le filtrage sous-thématiques

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -103,6 +103,9 @@ venv.bak/
 # mypy
 .mypy_cache/
 
+# Frontend stuff
+.sass-cache
+
 TODO
 
 .env.local

--- a/src/static/css/_globals.scss
+++ b/src/static/css/_globals.scss
@@ -880,6 +880,17 @@ iframe#stats-optout {
     }
 }
 
+// Make select2 result box bigger
+// ul.select2-results__options {
+.select2-container--bootstrap4 .select2-results > .select2-results__options {
+    max-height: 400px !important;
+}
+
+.select2-container--bootstrap4 .select2-results__group {
+    color: #16181b !important;
+    background-color: #dfe0e1 !important;
+}
+
 
 span {
     // Allow to set two labels in some places. The short label will


### PR DESCRIPTION
https://trello.com/c/CQJXyZxK/565-formulaire-pp-revoir-la-s%C3%A9lection-des-th%C3%A9matiques-ss-th%C3%A9matiques

Modifications apportées
- les sous-thématiques sont groupées par thématiques dans le select
- on affiche seulement le nom de la sous-thématique et non "THEMATIQUE > sous-thématique"

![v3](https://user-images.githubusercontent.com/7147385/99706433-53410680-2a9b-11eb-9145-a0e856b6bba9.png)
