### PR TITLE
fix bug aids-previsualisation-with-safari-browser

### DIFF
--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -616,6 +616,10 @@ div#aid-preview-modal {
 
     div.content {
         padding: 0 0 1rem 0;
+        width: 100%;
+        height: 100%;
+        -webkit-overflow-scrolling: touch;
+        overflow-y: scroll;
     }
 
     iframe {


### PR DESCRIPTION
Corrige un bug d'affichage lors de la prévisualisation d'une aide par un contributeur avec le navigateur Safari. https://trello.com/c/MokcAFa8/767-pr%C3%A9visualisation-des-aides

La fenêtre pop-up permettant la prévisualisation de l'aide réduit le contenu de l'iframe et remplit quasi totalement la fenêtre en blanc). Ce bug d'affichage de l'iframe semble être classique sur Safari.  

Ajout des propriétés `width`, `height` et `overflow-y` à la div parente de l'iframe afin de forcer l'affichage de l'iframe avec la bonne `height`. 