### PR TITLE
change url for contribute-btn

### DIFF
--- a/src/templates/_footer.html
+++ b/src/templates/_footer.html
@@ -23,16 +23,13 @@
                 <p>{% blocktrans trimmed %}
                 Login now and publish your aids.
                 {% endblocktrans %}</p>
-
+                <a class="ml-btn" href="{% url 'aid_draft_list_view' %}">
                 {% if user.is_authenticated %}
-                    <a class="ml-btn" href="{% url 'aid_draft_list_view' %}">
-                        {{ _('Contribute now') }}
-                    </a>
+                    {{ _('Contribute now') }}
                 {% else %}
-                    <a class="ml-btn" href="{% url 'login' %}">
-                        {{ _('Login and contribute') }}
-                    </a>
+                    {{ _('Login and contribute') }}
                 {% endif %}
+                </a>
             </div>
 
             <div class="logos logos-2">


### PR DESCRIPTION
Modifie l'url utilisée dans le footer pour le bouton "`contribuez"/"connectez-vous et contribuez`". 

Que l'utilisateur soit connecté ou non on utilise le lien `{% url 'aid_draft_list_view' %}` car la view `AirDraftListView `contrôle déjà si l'utilisateur est connecté et renvoi à la page connection si ça n'est pas le cas grâce à la class `ContributorRequiredMixin`

Cela règle un problème de renvoi systématique au formulaire de mise à jour du profil contributeur. 

https://trello.com/c/ydFzOUCu/766-page-daccueil-porteur-daide