### PR TITLE
Admin : rajoute des filtres dans le modèle Aid

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,6 +24,7 @@ zipp = "<2"  # https://github.com/jaraco/zipp/issues/28
 django-cors-headers = "*"
 django-activity-stream = "*"
 django-import-export = "*"
+django-admin-autocomplete-filter = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d4239c12108b12df2c5c26556cd54da57dc9775b0545e28267ca01cd2db9bfe8"
+            "sha256": "38a40bad359e545023944f3a9cc65ea03fdf475b602dd43d39ac643f120bf094"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "amqp": {
             "hashes": [
-                "sha256:9881f8e6fe23e3db9faa6cfd8c05390213e1d1b95c0162bc50552cad75bffa5f",
-                "sha256:a8fb8151eb9d12204c9f1784c0da920476077609fa0a70f2468001e3a4258484"
+                "sha256:5b9062d5c0812335c75434bf17ce33d7a20ecfedaa0733faec7379868eb4068a",
+                "sha256:fcd5b3baeeb7fc19b3486ff6d10543099d40ae1f5c9196eae695d1cde1b2f784"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==5.0.1"
+            "version": "==5.0.2"
         },
         "attrs": {
             "hashes": [
@@ -65,10 +65,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
-                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
+                "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd",
+                "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"
             ],
-            "version": "==2020.6.20"
+            "version": "==2020.11.8"
         },
         "cffi": {
             "hashes": [
@@ -214,6 +214,14 @@
             "index": "pypi",
             "version": "==0.9.0"
         },
+        "django-admin-autocomplete-filter": {
+            "hashes": [
+                "sha256:0358594110e5e498306388a9e4a0a2b57dde3abd302f9945337396003345af04",
+                "sha256:5016a8cb9aff7a7e7a796870ac572ac248a17d36339215878df9ba24761ce65f"
+            ],
+            "index": "pypi",
+            "version": "==0.6.1"
+        },
         "django-appconf": {
             "hashes": [
                 "sha256:1b1d0e1069c843ebe8ae5aa48ec52403b1440402b320c3e3a206a0907e97bb06",
@@ -337,11 +345,11 @@
         },
         "itemloaders": {
             "hashes": [
-                "sha256:a7803a1c27177d73329a0cc83a9c10de50fa4d4f37970e0194e8ae24b1fb7066",
-                "sha256:d8f92a93d0cc9f5a7f72f01562539cb7030f7741758e764a0a8716f9b0210f7a"
+                "sha256:1277cd8ca3e4c02dcdfbc1bcae9134ad89acfa6041bd15b4561c6290203a0c96",
+                "sha256:4cb46a0f8915e910c770242ae3b60b1149913ed37162804f1e40e8535d6ec497"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==1.0.3"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.4"
         },
         "jdcal": {
             "hashes": [
@@ -453,41 +461,41 @@
         },
         "psycopg2-binary": {
             "hashes": [
-                "sha256:1fabed9ea2acc4efe4671b92c669a213db744d2af8a9fc5d69a8e9bc14b7a9db",
-                "sha256:f5ab93a2cb2d8338b1674be43b442a7f544a0971da062a5da774ed40587f18f5",
-                "sha256:6a32f3a4cb2f6e1a0b15215f448e8ce2da192fd4ff35084d80d5e39da683e79b",
-                "sha256:833709a5c66ca52f1d21d41865a637223b368c0ee76ea54ca5bad6f2526c7679",
-                "sha256:e74a55f6bad0e7d3968399deb50f61f4db1926acf4a6d83beaaa7df986f48b1c",
+                "sha256:0deac2af1a587ae12836aa07970f5cb91964f05a7c6cdb69d8425ff4c15d4e2c",
                 "sha256:0e4dc3d5996760104746e6cfcdb519d9d2cd27c738296525d5867ea695774e67",
-                "sha256:ee69dad2c7155756ad114c02db06002f4cded41132cc51378e57aad79cc8e4f4",
-                "sha256:15978a1fbd225583dd8cdaf37e67ccc278b5abecb4caf6b2d6b8e2b948e953f6",
                 "sha256:11b9c0ebce097180129e422379b824ae21c8f2a6596b159c7659e2e5a00e1aa0",
-                "sha256:42ec1035841b389e8cc3692277a0bd81cdfe0b65d575a2c8862cec7a80e62e52",
-                "sha256:e1f57aa70d3f7cc6947fd88636a481638263ba04a742b4a37dd25c373e41491a",
-                "sha256:89705f45ce07b2dfa806ee84439ec67c5d9a0ef20154e0e475e2b2ed392a5b83",
-                "sha256:a0eb43a07386c3f1f1ebb4dc7aafb13f67188eab896e7397aa1ee95a9c884eb2",
-                "sha256:6422f2ff0919fd720195f64ffd8f924c1395d30f9a495f31e2392c2efafb5056",
-                "sha256:ac0c682111fbf404525dfc0f18a8b5f11be52657d4f96e9fcb75daf4f3984859",
-                "sha256:ba381aec3a5dc29634f20692349d73f2d21f17653bda1decf0b52b11d694541f",
+                "sha256:15978a1fbd225583dd8cdaf37e67ccc278b5abecb4caf6b2d6b8e2b948e953f6",
+                "sha256:1fabed9ea2acc4efe4671b92c669a213db744d2af8a9fc5d69a8e9bc14b7a9db",
                 "sha256:2dac98e85565d5688e8ab7bdea5446674a83a3945a8f416ad0110018d1501b94",
-                "sha256:e82aba2188b9ba309fd8e271702bd0d0fc9148ae3150532bbb474f4590039ffb",
+                "sha256:42ec1035841b389e8cc3692277a0bd81cdfe0b65d575a2c8862cec7a80e62e52",
+                "sha256:6422f2ff0919fd720195f64ffd8f924c1395d30f9a495f31e2392c2efafb5056",
+                "sha256:6a32f3a4cb2f6e1a0b15215f448e8ce2da192fd4ff35084d80d5e39da683e79b",
+                "sha256:7312e931b90fe14f925729cde58022f5d034241918a5c4f9797cac62f6b3a9dd",
+                "sha256:7d92a09b788cbb1aec325af5fcba9fed7203897bbd9269d5691bb1e3bce29550",
+                "sha256:833709a5c66ca52f1d21d41865a637223b368c0ee76ea54ca5bad6f2526c7679",
+                "sha256:89705f45ce07b2dfa806ee84439ec67c5d9a0ef20154e0e475e2b2ed392a5b83",
                 "sha256:8cd0fb36c7412996859cb4606a35969dd01f4ea34d9812a141cd920c3b18be77",
                 "sha256:950bc22bb56ee6ff142a2cb9ee980b571dd0912b0334aa3fe0fe3788d860bea2",
-                "sha256:0deac2af1a587ae12836aa07970f5cb91964f05a7c6cdb69d8425ff4c15d4e2c",
+                "sha256:a0c50db33c32594305b0ef9abc0cb7db13de7621d2cadf8392a1d9b3c437ef77",
+                "sha256:a0eb43a07386c3f1f1ebb4dc7aafb13f67188eab896e7397aa1ee95a9c884eb2",
+                "sha256:aaa4213c862f0ef00022751161df35804127b78adf4a2755b9f991a507e425fd",
+                "sha256:ac0c682111fbf404525dfc0f18a8b5f11be52657d4f96e9fcb75daf4f3984859",
                 "sha256:ad20d2eb875aaa1ea6d0f2916949f5c08a19c74d05b16ce6ebf6d24f2c9f75d1",
                 "sha256:b4afc542c0ac0db720cf516dd20c0846f71c248d2b3d21013aa0d4ef9c71ca25",
-                "sha256:d5227b229005a696cc67676e24c214740efd90b148de5733419ac9aaba3773da",
-                "sha256:aaa4213c862f0ef00022751161df35804127b78adf4a2755b9f991a507e425fd",
-                "sha256:d1b4ab59e02d9008efe10ceabd0b31e79519da6fb67f7d8e8977118832d0f449",
-                "sha256:7d92a09b788cbb1aec325af5fcba9fed7203897bbd9269d5691bb1e3bce29550",
+                "sha256:b8a3715b3c4e604bcc94c90a825cd7f5635417453b253499664f784fc4da0152",
+                "sha256:ba28584e6bca48c59eecbf7efb1576ca214b47f05194646b081717fa628dfddf",
+                "sha256:ba381aec3a5dc29634f20692349d73f2d21f17653bda1decf0b52b11d694541f",
+                "sha256:bd1be66dde2b82f80afb9459fc618216753f67109b859a361cf7def5c7968729",
                 "sha256:c2507d796fca339c8fb03216364cca68d87e037c1f774977c8fc377627d01c71",
                 "sha256:cec7e622ebc545dbb4564e483dd20e4e404da17ae07e06f3e780b2dacd5cee66",
                 "sha256:d14b140a4439d816e3b1229a4a525df917d6ea22a0771a2a78332273fd9528a4",
-                "sha256:b8a3715b3c4e604bcc94c90a825cd7f5635417453b253499664f784fc4da0152",
-                "sha256:bd1be66dde2b82f80afb9459fc618216753f67109b859a361cf7def5c7968729",
-                "sha256:a0c50db33c32594305b0ef9abc0cb7db13de7621d2cadf8392a1d9b3c437ef77",
-                "sha256:7312e931b90fe14f925729cde58022f5d034241918a5c4f9797cac62f6b3a9dd",
-                "sha256:ba28584e6bca48c59eecbf7efb1576ca214b47f05194646b081717fa628dfddf"
+                "sha256:d1b4ab59e02d9008efe10ceabd0b31e79519da6fb67f7d8e8977118832d0f449",
+                "sha256:d5227b229005a696cc67676e24c214740efd90b148de5733419ac9aaba3773da",
+                "sha256:e1f57aa70d3f7cc6947fd88636a481638263ba04a742b4a37dd25c373e41491a",
+                "sha256:e74a55f6bad0e7d3968399deb50f61f4db1926acf4a6d83beaaa7df986f48b1c",
+                "sha256:e82aba2188b9ba309fd8e271702bd0d0fc9148ae3150532bbb474f4590039ffb",
+                "sha256:ee69dad2c7155756ad114c02db06002f4cded41132cc51378e57aad79cc8e4f4",
+                "sha256:f5ab93a2cb2d8338b1674be43b442a7f544a0971da062a5da774ed40587f18f5"
             ],
             "index": "pypi",
             "version": "==2.8.6"
@@ -567,17 +575,19 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
                 "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76",
-                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
-                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
-                "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf",
-                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
-                "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2",
-                "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee",
-                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
                 "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
-                "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
+                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
+                "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e",
+                "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a",
+                "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf",
+                "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee",
+                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
+                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
+                "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2",
+                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
+                "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a",
+                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"
             ],
             "version": "==5.3.1"
         },
@@ -604,11 +614,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
-                "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"
+                "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8",
+                "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"
             ],
             "index": "pypi",
-            "version": "==2.24.0"
+            "version": "==2.25.0"
         },
         "rjsmin": {
             "hashes": [
@@ -630,11 +640,11 @@
         },
         "scrapy": {
             "hashes": [
-                "sha256:4ea7fbc902ee0b0a79b154d07a5f4e747e2146f272a748557941946000728479",
-                "sha256:6dace3499c8ca5bef1b7bb8a517cdfcc12c1e685f7ec4158f6e48f2d706e7c1d"
+                "sha256:27621ab491706ec8cc41168cdbdff07e7fe8c344c8640e9e9faebd7cf84008e2",
+                "sha256:68c48f01a58636bdf0f6fcd5035a19ecf277b58af24bd70c36dc6e556df3e005"
             ],
             "index": "pypi",
-            "version": "==2.4.0"
+            "version": "==2.4.1"
         },
         "service-identity": {
             "hashes": [
@@ -721,11 +731,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
-                "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
+                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
+                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.25.11"
+            "version": "==1.26.2"
         },
         "vine": {
             "hashes": [
@@ -862,11 +872,11 @@
         },
         "asgiref": {
             "hashes": [
-                "sha256:a5098bc870b80e7b872bff60bb363c7f2c2c89078759f6c47b53ff8c525a152e",
-                "sha256:cd88907ecaec59d78e4ac00ea665b03e571cb37e3a0e37b3702af1a9e86c365a"
+                "sha256:5ee950735509d04eb673bd7f7120f8fa1c9e2df495394992c73234d526907e17",
+                "sha256:7162a3cb30ab0609f1a4c95938fd73e8604f63bdba516a7f7d64b83ff09478f0"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.3.0"
+            "version": "==3.3.1"
         },
         "attrs": {
             "hashes": [
@@ -985,11 +995,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:6afc461ab3f779c9c16e299fc731d775e39ea7e8e063b3053ee359ae198a15ca",
-                "sha256:ce1c38823eb0f927567cde5bf2e7c8ca565c7a70316139342050ce2ca74b4026"
+                "sha256:5398268e1d751ffdb3ed36b8a790ed98659200599b368eec38a02eed15bce997",
+                "sha256:d4183b8f57316de3be27cd6c3b40e9f9343d27c95c96179f027316c58c2c239e"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==4.14.2"
+            "version": "==4.17.1"
         },
         "flake8": {
             "hashes": [
@@ -1218,17 +1228,19 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
                 "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76",
-                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
-                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
-                "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf",
-                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
-                "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2",
-                "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee",
-                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
                 "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
-                "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
+                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
+                "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e",
+                "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a",
+                "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf",
+                "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee",
+                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
+                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
+                "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2",
+                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
+                "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a",
+                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"
             ],
             "version": "==5.3.1"
         },
@@ -1288,11 +1300,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
-                "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
+                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
+                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.25.11"
+            "version": "==1.26.2"
         },
         "wcwidth": {
             "hashes": [

--- a/src/aids/admin.py
+++ b/src/aids/admin.py
@@ -12,10 +12,12 @@ from import_export import fields, resources
 from import_export.admin import ExportActionMixin
 from import_export.formats import base_formats
 from import_export.widgets import ForeignKeyWidget, ManyToManyWidget
+from admin_auto_filters.filters import AutocompleteFilter
 
 from aids.admin_views import AmendmentMerge
 from aids.forms import AidAdminForm
 from aids.models import Aid
+from geofr.utils import search_perimeter_by_id
 from core.admin import InputFilter
 from upload.settings import TRUMBOWYG_UPLOAD_ADMIN_JS
 
@@ -100,6 +102,18 @@ class PerimeterFilter(InputFilter):
         value = self.value()
         if value is not None:
             return queryset.filter(Q(perimeter__name__icontains=value))
+
+
+class PerimeterAutocompleteFilter(AutocompleteFilter):
+    field_name = 'perimeter'
+    title = _('Perimeter')
+    use_pk_exact = False
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value is not None:
+            perimeter_qs = search_perimeter_by_id(value)
+            return queryset.filter(perimeter__in=perimeter_qs)
 
 
 class AidResource(resources.ModelResource):
@@ -217,7 +231,8 @@ class BaseAidAdmin(ExportActionMixin, admin.ModelAdmin):
     list_filter = [
         'status', 'recurrence', 'is_imported', 'is_call_for_project',
         'in_france_relance',
-        LiveAidListFilter, AuthorFilter, BackersFilter, PerimeterFilter,
+        LiveAidListFilter, AuthorFilter, BackersFilter,
+        PerimeterAutocompleteFilter,
         'programs', 'categories']
 
     filter_vertical = ['categories']  # Overriden in the widget definition

--- a/src/aids/admin.py
+++ b/src/aids/admin.py
@@ -217,7 +217,8 @@ class BaseAidAdmin(ExportActionMixin, admin.ModelAdmin):
     list_filter = [
         'status', 'recurrence', 'is_imported', 'is_call_for_project',
         'in_france_relance',
-        LiveAidListFilter, AuthorFilter, BackersFilter, PerimeterFilter]
+        LiveAidListFilter, AuthorFilter, BackersFilter, PerimeterFilter,
+        'programs', 'categories']
 
     filter_vertical = ['categories']  # Overriden in the widget definition
     readonly_fields = [

--- a/src/aids/admin.py
+++ b/src/aids/admin.py
@@ -17,7 +17,7 @@ from admin_auto_filters.filters import AutocompleteFilter
 from aids.admin_views import AmendmentMerge
 from aids.forms import AidAdminForm
 from aids.models import Aid
-from geofr.utils import search_perimeter_by_id
+from geofr.utils import get_all_related_perimeter_ids
 from core.admin import InputFilter
 from upload.settings import TRUMBOWYG_UPLOAD_ADMIN_JS
 
@@ -112,7 +112,7 @@ class PerimeterAutocompleteFilter(AutocompleteFilter):
     def queryset(self, request, queryset):
         value = self.value()
         if value is not None:
-            perimeter_qs = search_perimeter_by_id(value)
+            perimeter_qs = get_all_related_perimeter_ids(value)
             return queryset.filter(perimeter__in=perimeter_qs)
 
 
@@ -121,34 +121,34 @@ class AidResource(resources.ModelResource):
 
     # custom widgets to ForeignKey/ManyToMany information instead of ids
     author = fields.Field(
-        column_name="author",
-        attribute="author",
-        widget=ForeignKeyWidget('accounts.User', field="full_name")
+        column_name='author',
+        attribute='author',
+        widget=ForeignKeyWidget('accounts.User', field='full_name')
     )
     categories = fields.Field(
-        column_name="categories",
-        attribute="categories",
-        widget=ManyToManyWidget('categories.Category', field="name")
+        column_name='categories',
+        attribute='categories',
+        widget=ManyToManyWidget('categories.Category', field='name')
     )
     financers = fields.Field(
-        column_name="financers",
-        attribute="financers",
-        widget=ManyToManyWidget('backers.Backer', field="name")
+        column_name='financers',
+        attribute='financers',
+        widget=ManyToManyWidget('backers.Backer', field='name')
     )
     instructors = fields.Field(
-        column_name="instructors",
-        attribute="instructors",
-        widget=ManyToManyWidget('backers.Backer', field="name")
+        column_name='instructors',
+        attribute='instructors',
+        widget=ManyToManyWidget('backers.Backer', field='name')
     )
     perimeter = fields.Field(
-        column_name="perimeter",
-        attribute="perimeter",
-        widget=ForeignKeyWidget('geofr.Perimeter', field="name")
+        column_name='perimeter',
+        attribute='perimeter',
+        widget=ForeignKeyWidget('geofr.Perimeter', field='name')
     )
     programs = fields.Field(
-        column_name="programs",
-        attribute="programs",
-        widget=ManyToManyWidget('programs.Program', field="name")
+        column_name='programs',
+        attribute='programs',
+        widget=ManyToManyWidget('programs.Program', field='name')
     )
 
     class Meta:

--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -12,7 +12,7 @@ from core.forms import (
     AutocompleteModelChoiceField, AutocompleteModelMultipleChoiceField,
     MultipleChoiceFilterWidget, RichTextField)
 from geofr.models import Perimeter
-from geofr.utils import search_perimeter_by_id
+from geofr.utils import get_all_related_perimeter_ids
 from backers.models import Backer
 from categories.fields import CategoryMultipleChoiceField
 from categories.models import Category, Theme
@@ -693,7 +693,7 @@ class BaseAidSearchForm(forms.Form):
          - M3M (and all other epcis in Hérault) ;
          - Montpellier (and all other communes in Hérault) ;
         """
-        perimeter_qs = search_perimeter_by_id(search_perimeter.id)
+        perimeter_qs = get_all_related_perimeter_ids(search_perimeter.id)
         qs = qs.filter(perimeter__in=perimeter_qs)
         return qs
 

--- a/src/core/settings/base.py
+++ b/src/core/settings/base.py
@@ -36,6 +36,7 @@ THIRD_PARTY_APPS = [
     'corsheaders',
     'actstream',
     'import_export',
+    'admin_auto_filters',
 ]
 
 LOCAL_APPS = [

--- a/src/geofr/tests/test_utils.py
+++ b/src/geofr/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 from geofr.utils import (department_from_zipcode, is_overseas,
+                         get_all_related_perimeter_ids,
                          attach_perimeters, attach_epci_perimeters)
 from geofr.factories import Perimeter, PerimeterFactory
 
@@ -20,6 +21,16 @@ def test_is_overseas():
     assert not is_overseas('27370')
     assert is_overseas('97200')
     assert is_overseas('97414')
+
+
+def test_get_all_related_perimeter_ids(perimeters):
+    """Finding related perimeters works as expected."""
+
+    related_perimeters_france = get_all_related_perimeter_ids(perimeters['herault'].id)  # noqa
+    print(related_perimeters_france)
+    assert {'id': perimeters['france'].id} in related_perimeters_france
+    assert {'id': perimeters['montpellier'].id} in related_perimeters_france
+    assert {'id': perimeters['aveyron'].id} not in related_perimeters_france
 
 
 def test_attach_perimeters(perimeters):

--- a/src/geofr/utils.py
+++ b/src/geofr/utils.py
@@ -31,12 +31,12 @@ def is_overseas(zipcode):
     return zipcode.startswith(OVERSEAS_PREFIX)
 
 
-def search_perimeter_by_id(search_perimeter_id):
-    """Filter queryset depending on the given perimeter.
+def get_all_related_perimeter_ids(search_perimeter_id):
+    """Return a list of all perimeter ids related to the searched perimeter.
 
-    When we search for a given perimeter, we must return all aids:
+    When we filter by a given perimeter, we must return all aids:
         - where the perimeter is wider and contains the searched perimeter ;
-        - where the perimeter is smaller and contained by the search
+        - where the perimeter is smaller and contained by the searched
         perimeter ;
 
     E.g if we search for aids in "Hérault (department), we must display all

--- a/src/geofr/utils.py
+++ b/src/geofr/utils.py
@@ -1,6 +1,7 @@
 import collections
 
 from django.db import transaction
+from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 
 from geofr.constants import OVERSEAS_PREFIX, DEPARTMENT_TO_REGION
@@ -28,6 +29,54 @@ def is_overseas(zipcode):
     """Tell if the given zipcode is overseas or mainland."""
 
     return zipcode.startswith(OVERSEAS_PREFIX)
+
+
+def search_perimeter_by_id(search_perimeter_id):
+    """Filter queryset depending on the given perimeter.
+
+    When we search for a given perimeter, we must return all aids:
+        - where the perimeter is wider and contains the searched perimeter ;
+        - where the perimeter is smaller and contained by the search
+        perimeter ;
+
+    E.g if we search for aids in "Hérault (department), we must display all
+    aids that are applicable to:
+
+        - Hérault ;
+        - Occitanie ;
+        - France ;
+        - Europe ;
+        - M3M (and all other epcis in Hérault) ;
+        - Montpellier (and all other communes in Hérault) ;
+    """
+
+    # Note: the original way we adressed this was more straightforward,
+    # but we got very very bad perf results (like, queries with very slow
+    # execution times > 30s).
+    # Thus, we had to "help" Postgres' execution planner a little.
+
+    # We just need to efficiently get a list of all perimeter ids related
+    # to the current query.
+
+    Through = Perimeter.contained_in.through
+    contains_id = Through.objects \
+        .filter(from_perimeter_id=search_perimeter_id) \
+        .values('to_perimeter_id') \
+        .distinct()
+    contained_id = Through.objects \
+        .filter(to_perimeter_id=search_perimeter_id) \
+        .values('from_perimeter_id') \
+        .distinct()
+
+    q_exact_match = Q(id=search_perimeter_id)
+    q_contains = Q(id__in=contains_id)
+    q_contained = Q(id__in=contained_id)
+
+    perimeter_qs = Perimeter.objects \
+        .filter(q_exact_match | q_contains | q_contained) \
+        .values('id') \
+        .distinct()
+    return perimeter_qs
 
 
 def extract_perimeters_from_file(perimeter_list_file):


### PR DESCRIPTION
https://trello.com/c/kTiYjojW/804-nouveaux-champs-de-filtrage-dans-ladmin

Modifications apportées : 
- ajout d'un filtre "par Programmes"
- ajout d'un filtre "par Sous-thématiques"
- remplace le filtre "par Périmètres"
  - avant : recherche simple sur le nom + filtre exacte sur les aides ayant ce périmètre
  - après : recherche autocomplete (select2) + filtre habituel des périmètres (toutes les aides ayant ce périmètre + incluses dans ce périmètre)

Pour cette dernière modif j'ai du installer un package additionnel, [django-admin-autocomplete-filter](https://github.com/farhan0581/django-admin-autocomplete-filter) car par défaut l'autocomplete est seulement disponible lors de la modification d'une aide, pas dans les filtres de la page list

Avant / Après
<p>
<img width="45%" alt="Screenshot 2020-11-23 at 23 26 39" src="https://user-images.githubusercontent.com/7147385/100063127-fba2f200-2e30-11eb-9c21-a77b0834ab2d.png">
<img width="45%" alt="Screenshot 2020-11-23 at 23 26 39" src="https://user-images.githubusercontent.com/7147385/100063132-fd6cb580-2e30-11eb-93eb-7f3b36d88358.png">
</p>