### PR TITLE
Créé une page de confirmation d'optin pour les contacts ADDNA

### DIFF
--- a/src/home/urls.py
+++ b/src/home/urls.py
@@ -3,7 +3,7 @@ from django.views.generic import TemplateView
 from django.utils.translation import ugettext_lazy as _
 
 from home.views import (HomeView, NewsletterConfirmView,
-                        NewsletterSuccessView)
+                        NewsletterSuccessView, ADDNAOptin)
 
 urlpatterns = [
     path('', HomeView.as_view(), name='home'),
@@ -17,4 +17,6 @@ urlpatterns = [
          name='confirm-registration-newsletter'),
     path(_('register-newsletter-success/'), NewsletterSuccessView.as_view(),
          name='register_newsletter_success'),
+
+    path('alertes-addna-optin/', ADDNAOptin.as_view(), name='addna_optin'),
 ]

--- a/src/home/views.py
+++ b/src/home/views.py
@@ -44,3 +44,9 @@ class NewsletterSuccessView(TemplateView):
     """Display success message after register action."""
 
     template_name = 'home/newsletter_success.html'
+
+
+class ADDNAOptin(TemplateView):
+    """Display a welcome message to users from addna."""
+
+    template_name = 'home/addna_optin.html'

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-23 11:28+0100\n"
+"POT-Creation-Date: 2020-11-24 15:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2376,6 +2376,33 @@ msgstr ""
 msgid "Register to the mailing-list"
 msgstr "S'inscrire à la lettre d'information"
 
+msgid "You have successfully subscribed"
+msgstr "Vous êtes abonné"
+
+msgid "Your subscription is now confirmed"
+msgstr "Votre inscription est confirmée"
+
+msgid ""
+"You have successfully subscribed to the ADDNA x Aides-territoires alert "
+"system."
+msgstr ""
+"Vous avez confirmé votre abonnement aux alertes ADDNA x Aides-territoires."
+
+#, python-format
+msgid ""
+"If you want to know more, <a href=\"%(legal_mentions_url)s\"> check out our "
+"terms of service</a>."
+msgstr ""
+"Si vous souhaitez en savoir plus, vous pouvez <a href="
+"\"%(legal_mentions_url)s\">consulter nos mentions légales</a>."
+
+msgid ""
+"You can now <a href=\"https://addna.aides-territoires.beta.gouv.fr/\"> visit "
+"the custom ADDNA page on Aides-territoires</a>."
+msgstr ""
+"Rendez-vous sur <a href=\"https://addna.aides-territoires.beta.gouv.fr/\">la "
+"page dédiée de l'ADDNA sur Aides-territoires</a>."
+
 msgid "Subscription confirmed"
 msgstr "Inscription confirmée"
 
@@ -2434,9 +2461,6 @@ msgid ""
 msgstr ""
 "Afin de finaliser votre inscription, il vous reste à cliquer sur le lien de "
 "confirmation présent dans l'e-mail que vous allez recevoir."
-
-msgid "You have successfully subscribed"
-msgstr "Vous êtes abonné"
 
 msgid "Thank you for subscribing to the newsletter"
 msgstr "Merci pour votre abonnement à la newsletter"

--- a/src/templates/home/addna_optin.html
+++ b/src/templates/home/addna_optin.html
@@ -1,0 +1,31 @@
+{% extends '_base.html' %}
+{% load i18n %}
+
+{% block extraclasses %}light{% endblock %}
+
+{% block sectionid %}login-form{% endblock %}
+
+{% block extratitle %}{{ _('You have successfully subscribed') }}{% endblock %}
+
+{% block content %}
+<div class="article narrow">
+    <h1>{{ _("Your subscription is now confirmed") }}</h1>
+
+    <p>{% blocktrans trimmed %}
+        You have successfully subscribed to the ADDNA x Aides-territoires alert
+        system.
+     {% endblocktrans %}</p>
+
+    {% url 'legal_mentions' as legal_mentions_url %}
+    <p>{% blocktrans trimmed %}
+        If you want to know more, <a href="{{ legal_mentions_url }}">
+            check out our terms of service</a>.
+     {% endblocktrans %}</p>
+
+    <p>{% blocktrans trimmed %}
+        You can now <a href="https://addna.aides-territoires.beta.gouv.fr/">
+        visit the custom ADDNA page on Aides-territoires</a>.
+     {% endblocktrans %}</p>
+
+</div>
+{% endblock %}


### PR DESCRIPTION
https://trello.com/c/i3YSKwGN/810-mise-en-place-de-loptin-pour-les-alertes-addna

Création d'une url spécifique qui sera mentionnée dans la campagne ADDNA.

Depuis Sendinblue, il sera ensuite possible de créer un filtre pour extraire les contacts ayant cliqués sur ce lien.