### PR TITLE
Admin : enlever certains champs lors de l'export d'aides

### DIFF
--- a/src/aids/admin.py
+++ b/src/aids/admin.py
@@ -20,6 +20,15 @@ from core.admin import InputFilter
 from upload.settings import TRUMBOWYG_UPLOAD_ADMIN_JS
 
 
+AIDS_EXPORT_EXCLUDE_FIELDS = [
+    'financer_suggestion', 'instructor_suggestion', 'perimeter_suggestion',
+    'contact_email', 'contact_phone', 'contact_detail',
+    'import_uniqueid', 'import_share_licence', 'import_last_access',
+    'search_vector', 'tags', '_tags_m2m',
+    'is_amendment', 'amended_aid', 'amendment_author_name', 'amendment_author_email', 'amendment_author_org', 'amendment_comment',  # noqa
+]
+
+
 class LiveAidListFilter(admin.SimpleListFilter):
     """Custom admin filter to target aids with various statuses."""
 
@@ -122,11 +131,17 @@ class AidResource(resources.ModelResource):
         attribute="perimeter",
         widget=ForeignKeyWidget('geofr.Perimeter', field="name")
     )
+    programs = fields.Field(
+        column_name="programs",
+        attribute="programs",
+        widget=ManyToManyWidget('programs.Program', field="name")
+    )
 
     class Meta:
         model = Aid
+        exclude = AIDS_EXPORT_EXCLUDE_FIELDS
         # adding custom widgets breaks the usual order
-        export_order = [field.name for field in Aid._meta.fields]
+        export_order = [field.name for field in Aid._meta.fields if field.name not in AIDS_EXPORT_EXCLUDE_FIELDS]  # noqa
 
     def get_export_headers(self):
         """override get_export_headers() to translate field names."""

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -786,7 +786,7 @@ msgid "Is this a one-off aid, is it recurring or ongoing?"
 msgstr "L'aide est-elle ponctuelle, permanente, récurrente ?"
 
 msgid "Programs"
-msgstr "programmes"
+msgstr "Programmes"
 
 msgid "Status"
 msgstr "Statut"


### PR DESCRIPTION
https://trello.com/c/8T6tJKz2/803-am%C3%A9liorations-de-loutil-dexport-xls

Modifications apportées : 
- Enlever une 10aine de champs de l'export
- Rajouter le champ 'Programmes' qui manquait à l'export