### PR TITLE
Filtre sur les Porteurs d'aides dans la recherche

### DIFF
--- a/src/backers/api/views.py
+++ b/src/backers/api/views.py
@@ -17,15 +17,23 @@ class BackerViewSet(viewsets.ReadOnlyModelViewSet):
         """Filter data according to search query."""
 
         qs = Backer.objects.all()
+
         q = self.request.query_params.get('q', '')
         terms = q.split()
         q_filters = []
         for term in terms:
             if len(term) >= MIN_SEARCH_LENGTH:
                 q_filters.append(Q(name__icontains=term))
-
         if q_filters:
             qs = qs.filter(reduce(operator.and_, q_filters))
+
+        has_financed_aids = self.request.query_params.get('has_financed_aids', 'false')  # noqa
+        if has_financed_aids == 'true':
+            qs = qs.has_financed_aids()
+
+        has_published_financed_aids = self.request.query_params.get('has_published_financed_aids', 'false')  # noqa
+        if has_published_financed_aids == 'true':
+            qs = qs.has_published_financed_aids()
 
         qs = qs.order_by('name')
 

--- a/src/backers/factories.py
+++ b/src/backers/factories.py
@@ -11,3 +11,14 @@ class BackerFactory(DjangoModelFactory):
         model = Backer
 
     name = factory.Faker('company')
+
+    @factory.post_generation
+    def financed_aids(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        if extracted:
+            # A list of groups were passed in, use them
+            for aid in extracted:
+                self.financed_aids.add(aid)

--- a/src/backers/models.py
+++ b/src/backers/models.py
@@ -2,8 +2,23 @@ from django.db import models
 from django.db.models.expressions import RawSQL
 from django.utils.translation import ugettext_lazy as _
 
+from aids.models import AidWorkflow
+
 
 class BackerQuerySet(models.QuerySet):
+    """Custom queryset with additional filtering methods for backers."""
+
+    def is_aid_financer(self):
+        """Only return backers with financed_aids."""
+
+        return self.exclude(financed_aids=None)
+
+    def has_published_aids(self):
+        """Only return backers with published financed_aids."""
+
+        qs = self.filter(financed_aids__status=AidWorkflow.states.published) \
+            .distinct()
+        return qs
 
     def annotate_aids_count(self, related_fields, annotation_name):
         """Annotate the queryset with the number of related aids.

--- a/src/backers/models.py
+++ b/src/backers/models.py
@@ -8,12 +8,12 @@ from aids.models import AidWorkflow
 class BackerQuerySet(models.QuerySet):
     """Custom queryset with additional filtering methods for backers."""
 
-    def is_aid_financer(self):
+    def has_financed_aids(self):
         """Only return backers with financed_aids."""
 
         return self.exclude(financed_aids=None)
 
-    def has_published_aids(self):
+    def has_published_financed_aids(self):
         """Only return backers with published financed_aids."""
 
         qs = self.filter(financed_aids__status=AidWorkflow.states.published) \

--- a/src/backers/tests/test_api.py
+++ b/src/backers/tests/test_api.py
@@ -1,0 +1,56 @@
+import json
+import pytest
+from django.urls import reverse
+
+from backers.factories import BackerFactory
+from aids.models import AidWorkflow
+from aids.factories import AidFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def api_url():
+    return reverse('backers-list')
+
+
+def test_api(client, api_url):
+    BackerFactory(name='ADEME')
+    BackerFactory(name='Bpifrance')
+    BackerFactory(name='DINUM')
+
+    res = client.get(api_url)
+    assert res.status_code == 200
+    content = json.loads(res.content.decode())
+    assert content['count'] == 3
+
+
+def test_api_with_q_filter(client, api_url):
+    BackerFactory(name='ADEME')
+    BackerFactory(name='BPI')
+    BackerFactory(name='DINUM')
+
+    res = client.get(f'{api_url}?q=ade')
+    assert res.status_code == 200
+    content = json.loads(res.content.decode())
+    assert content['count'] == 1
+
+
+def test_api_with_financed_aids_filters(client, api_url):
+    BackerFactory()
+    aid_draft = AidFactory(status=AidWorkflow.states.draft)
+    BackerFactory(financed_aids=[aid_draft])
+    aid_published_1 = AidFactory(status=AidWorkflow.states.published)
+    aid_published_2 = AidFactory(status=AidWorkflow.states.published)
+    BackerFactory(financed_aids=[aid_published_1, aid_published_2])
+
+    res = client.get(f'{api_url}?has_financed_aids=true')
+    assert res.status_code == 200
+    content = json.loads(res.content.decode())
+    assert content['count'] == 2
+
+    res = client.get(f'{api_url}?has_published_financed_aids=true')
+    assert res.status_code == 200
+    content = json.loads(res.content.decode())
+    assert content['count'] == 1

--- a/src/backers/tests/test_models.py
+++ b/src/backers/tests/test_models.py
@@ -5,6 +5,7 @@ from backers.factories import BackerFactory
 from aids.models import AidWorkflow
 from aids.factories import AidFactory
 
+
 pytestmark = pytest.mark.django_db
 
 
@@ -18,5 +19,5 @@ def test_backer_filtering():
     BackerFactory(financed_aids=[aid_published_1, aid_published_2])
 
     assert Backer.objects.count() == 3
-    assert Backer.objects.is_aid_financer().count() == 2
-    assert Backer.objects.has_published_aids().count() == 1
+    assert Backer.objects.has_financed_aids().count() == 2
+    assert Backer.objects.has_published_financed_aids().count() == 1

--- a/src/backers/tests/test_models.py
+++ b/src/backers/tests/test_models.py
@@ -1,0 +1,22 @@
+import pytest
+
+from backers.models import Backer
+from backers.factories import BackerFactory
+from aids.models import AidWorkflow
+from aids.factories import AidFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_backer_filtering():
+
+    BackerFactory()
+    aid_draft = AidFactory(status=AidWorkflow.states.draft)
+    BackerFactory(financed_aids=[aid_draft])
+    aid_published_1 = AidFactory(status=AidWorkflow.states.published)
+    aid_published_2 = AidFactory(status=AidWorkflow.states.published)
+    BackerFactory(financed_aids=[aid_published_1, aid_published_2])
+
+    assert Backer.objects.count() == 3
+    assert Backer.objects.is_aid_financer().count() == 2
+    assert Backer.objects.has_published_aids().count() == 1

--- a/src/static/js/aids/backers_autocomplete.js
+++ b/src/static/js/aids/backers_autocomplete.js
@@ -14,6 +14,7 @@ $(document).ready(function () {
             data: function (params) {
                 var query = {
                   q: params.term,
+                  has_published_financed_aids: true,
                   page: params.page || 1
                 }
                 return query;


### PR DESCRIPTION
https://trello.com/c/4217jS5q/779-am%C3%A9liorer-la-liste-d%C3%A9roulante-des-porteurs-daides

Modifications apportées : 
- Dans le formulaire de recherche d'aide (simple et avancé), on affiche seulement les porteurs d'aides qui sont 'financeurs' et qui ont des aides publiées
- 2 nouveaux queryset dans le modèle `Backer`
- Ajout de filtres dans l'API du modèle `Backer`
- Ajout de tests