### PR TITLE
L'upload d'images restreint aux admins

### DIFF
--- a/src/aids/admin.py
+++ b/src/aids/admin.py
@@ -176,6 +176,7 @@ class BaseAidAdmin(ExportActionMixin, admin.ModelAdmin):
         }
         js = [
             'admin/js/jquery.init.js',
+            '/static/js/shared_config.js',
             '/static/js/plugins/softmaxlength.js',
             '/static/js/aids/enable_softmaxlength.js',
             '/static/trumbowyg/dist/trumbowyg.js',

--- a/src/pages/admin.py
+++ b/src/pages/admin.py
@@ -30,6 +30,7 @@ class PageAdmin(FlatPageAdmin):
         }
         js = [
             'admin/js/jquery.init.js',
+            '/static/js/shared_config.js',
             '/static/trumbowyg/dist/trumbowyg.js',
             '/static/trumbowyg/dist/langs/fr.js',
             '/static/js/enable_rich_text_editor.js',

--- a/src/search/admin.py
+++ b/src/search/admin.py
@@ -62,6 +62,7 @@ class SearchPageAdmin(admin.ModelAdmin):
         }
         js = [
             'admin/js/jquery.init.js',
+            '/static/js/shared_config.js',
             '/static/js/plugins/softmaxlength.js',
             '/static/js/search/enable_softmaxlength.js',
             '/static/trumbowyg/dist/trumbowyg.js',

--- a/src/static/js/enable_rich_text_editor_simple.js
+++ b/src/static/js/enable_rich_text_editor_simple.js
@@ -1,7 +1,6 @@
 (function ($) {
     'use strict';
     $(document).ready(function () {
-        trumbowygConfig.btns.push(['image'])  // An admin can add images
         $('textarea.textarea-wysiwyg').trumbowyg(trumbowygConfig);
     });
 }($ || django.jQuery));

--- a/src/static/js/shared_config.js
+++ b/src/static/js/shared_config.js
@@ -1,0 +1,30 @@
+// JS shared configurations are kept here.
+
+var trumbowygConfig = {
+    lang: 'fr',
+    btnsDef: {
+        image: {
+            dropdown: ['insertImage', 'upload'],
+            ico: 'insertImage'
+        }
+    },
+    btns: [
+        ['viewHTML'],
+        ['undo', 'redo'],
+        ['formatting'],
+        ['strong', 'em'],
+        ['link'],
+        ['unorderedList', 'orderedList'],
+        ['removeformat'],
+        ['fullscreen']
+    ],
+    minimalLinks: true,
+    removeformatPasted: true,
+    svgPath: '/static/trumbowyg/dist/ui/icons.svg',
+    plugins: {
+        upload: {
+            serverPath: '/upload/',
+            fileFieldName: 'image'
+        }
+    }
+}

--- a/src/templates/_base.html
+++ b/src/templates/_base.html
@@ -76,6 +76,7 @@
             var hotjar_siteid = {% hotjar_siteid %};
         </script>
         {% endcompress %}
+        <script src="/static/js/shared_config.js"></script>
         {% block extra_js %}{% endblock %}
 
         {% analytics_enabled as analytics_enabled %}

--- a/src/templates/admin/amend_ui.html
+++ b/src/templates/admin/amend_ui.html
@@ -102,6 +102,6 @@ modification that was suggested.
 <script src="/static/js/aids/categories_autocomplete.js"></script>
 <script src="/static/js/aids/programs_autocomplete.js"></script>
 <script src="/static/js/backers_autocomplete.js"></script>
-<script src="/static/js/enable_rich_text_editor.js"></script>
+<script src="/static/js/enable_rich_text_editor_simple.js"></script>
 {% endcompress %}
 {% endblock %}

--- a/src/templates/aids/_base_edit.html
+++ b/src/templates/aids/_base_edit.html
@@ -106,7 +106,6 @@
 <script src="/static/select2/dist/js/i18n/fr.js"></script>
 <script src="/static/trumbowyg/dist/trumbowyg.js"></script>
 <script src="/static/trumbowyg/dist/langs/fr.js"></script>
-<script src="/static/trumbowyg/dist/plugins/upload/trumbowyg.upload.js"></script>
 
 {% comment %}Custom homemade scripts{% endcomment %}
 <script src="/static/js/plugins/softmaxlength.js"></script>
@@ -120,6 +119,6 @@
 <script src="/static/js/aids/toggle_calendar_related_fields.js"></script>
 <script src="/static/js/aids/toggle_aid_instructor_field.js"></script>
 <script src="/static/js/aids/enable_softmaxlength.js"></script>
-<script src="/static/js/enable_rich_text_editor.js"></script>
+<script src="/static/js/enable_rich_text_editor_simple.js"></script>
 {% endcompress %}
 {% endblock %}


### PR DESCRIPTION
Il y a maintenant 2 fichiers JS pour la configuration Trubmowyg : Pour les admins et pour les porteurs d'aides non-admin.

On a aussi rajouté la notion de "shared config" pour qu'on ai un endroit où mettre les variables JS qui sont partagées.


```
Text Field: The image button is now only available for admin
There is a new JS file for shared config. That's where we put
variables that we need to share across several JS modules.
Typically, the Trumbowyg config is one of these variables,
since we have a config for site users and a slightly different
config to site admin.
```

https://trello.com/c/KlmODeqj/808-upload-dimage-dans-la-section-non-admin-on-ne-doit-pas-pouvoir-uploader-des-images