### PR TITLE
Corrige un bug sur la page admin/amendment - mobilization_steps

### DIFF
--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -329,7 +329,8 @@ class AidEditForm(BaseAidForm):
             range_widgets = self.fields['subvention_rate'].widget.widgets
             range_widgets[0].attrs['placeholder'] = _('Min. subvention rate')
             range_widgets[1].attrs['placeholder'] = _('Max. subvention rate')
-        self.fields['mobilization_steps'].required = True
+        if 'mobilization_steps' in self.fields:
+            self.fields['mobilization_steps'].required = True
 
     def clean(self):
         """Validation routine (frontend form only)."""


### PR DESCRIPTION
Correction d'un bug liée à la [PR](https://github.com/MTES-MCT/aides-territoires/commit/b47d6d304b101581870eb0ac6c663d9e6b5aa211) rendant obligatoire le champ `mobilization_steps` sur la page d'édition d'une aide. 
La page admin/amendment renvoi actuellement une erreur visant le champ `mobilization_steps` (https://trello.com/c/RO9nfOuY/812-bug-sur-la-page-admin-amendements-mobilizationsteps)

Ajout d'une condition dans la class `AidEditForm` pour rendre obligatoire le champ `mobilization_steps`. 