### PR TITLE
Portefeuille d'aides : change le tri et le nom d'une colonne

### DIFF
--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -280,7 +280,7 @@ class AidDraftListView(ContributorRequiredMixin, AidEditMixin, ListView):
         'submission_deadline',
         'status',
     ]
-    default_ordering = 'date_created'
+    default_ordering = '-date_updated'
 
     def get_queryset(self):
         qs = super().get_queryset()

--- a/src/templates/aids/draft_list.html
+++ b/src/templates/aids/draft_list.html
@@ -25,7 +25,7 @@
     <caption class="sr-only">{{ _('Your list of published aids') }}</caption>
     <thead>
         <tr>
-            <th>{% sortable_header _('Name') 'name' %}</th>
+            <th>{% sortable_header _('Aid title') 'name' %}</th>
             <th>{% sortable_header _('Created on') 'date_created' %}</th>
             <th>{% sortable_header _('Last modified') 'date_updated' %}</th>
             <th>{% sortable_header _('Deadline') 'submission_deadline' %}</th>


### PR DESCRIPTION
https://trello.com/c/vGTvsCs6/796-portefeuille-daide-mise-en-forme-des-colonnes

Modifications apportées : 
- colonne "Nom" devient "Nom de l'aide"
- le tri par défaut est maintenant "les plus récemment modifiées en haut"