### PR TITLE
Add a missing hidden field for prgrams on search form page

### DIFF
--- a/src/templates/aids/_search_form.html
+++ b/src/templates/aids/_search_form.html
@@ -16,6 +16,7 @@
         {{ form.targeted_audiences.as_hidden }}
         {{ form.perimeter.as_hidden }}
         {{ form.themes.as_hidden }}
+        {{ form.programs.as_hidden }}
     {% endblock %}
 
     {% block other_actions %}


### PR DESCRIPTION
Trello: https://trello.com/c/tV6yDEX1/757-recherche-daide-probl%C3%A8me-de-filtrage-sur-le-site-principal

Il y avait un bug :

- On est dans la page de recherche avancée et on cherche par "programmes"
- La page de résultat s'affiche bien.
- Mais quand on retourne dans la recherche avancée, le programme n'est plus là.


Il manquait le champs caché "programs" dans le formulaire principal, c'est pour ça...