### PR TITLE
Portefeuille d'aides : affiche le nombre de vues totales en haut

### DIFF
--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -304,8 +304,7 @@ class AidDraftListView(ContributorRequiredMixin, AidEditMixin, ListView):
             .filter(category='aid', event='viewed') \
             .filter(meta__in=aid_slugs)
 
-        events_total_count = events \
-            .count()
+        events_total_count = events.count()
 
         recent_30_days_ago = timezone.now() - timedelta(days=30)
         events_last_30_days_count = events \

--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib import messages
@@ -300,11 +302,24 @@ class AidDraftListView(ContributorRequiredMixin, AidEditMixin, ListView):
 
         events = Event.objects \
             .filter(category='aid', event='viewed') \
-            .filter(meta__in=aid_slugs) \
+            .filter(meta__in=aid_slugs)
+
+        events_total_count = events \
+            .count()
+
+        recent_30_days_ago = timezone.now() - timedelta(days=30)
+        events_last_30_days_count = events \
+            .filter(date_created__gte=recent_30_days_ago) \
+            .count()
+
+        events_total_count_per_aid = events \
             .values_list('meta') \
             .annotate(nb_views=Sum('value')) \
             .order_by('meta')
-        context['hits'] = dict(events)
+
+        context['hits_total'] = events_total_count
+        context['hits_last_30_days'] = events_last_30_days_count
+        context['hits_per_aid'] = dict(events_total_count_per_aid)
 
         return context
 

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-30 10:31+0100\n"
+"POT-Creation-Date: 2020-12-01 16:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2205,6 +2205,12 @@ msgstr "Lien vers un descriptif complet"
 
 msgid "Suggest a modification"
 msgstr "Suggérer des modifications"
+
+msgid "Total number of hits"
+msgstr "Nombre de vues total des aides"
+
+msgid "Number of hits in the last 30 days"
+msgstr "Nombre de vues sur les 30 derniers jours"
 
 msgid "Your list of published aids"
 msgstr "La liste de vos aides publiées"

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -1064,10 +1064,13 @@ section#amend-ui {
     }
 }
 
-section#draft-list {
-    table tr.expired {
-        td.deadline {
-            @include icon(before, $fa-var-exclamation-circle);
+article#draft-list {
+    div.info {
+        span.counter {
+            @extend .badge;
+            @extend .badge-pill;
+            @extend .badge-light;
+            font-size: 125%;
         }
     }
 }

--- a/src/static/css/_globals.scss
+++ b/src/static/css/_globals.scss
@@ -1037,3 +1037,4 @@ p:last-child {
     position: absolute;
     left: -9999px;
 }
+

--- a/src/templates/aids/draft_list.html
+++ b/src/templates/aids/draft_list.html
@@ -21,6 +21,11 @@
 
 <h1>{{ _('My portfolio') }}</h1>
 
+<div class="info">
+    {{ _('Total number of hits') }} : <span class="counter">{{ hits_total }}</span><br />
+    {{ _('Number of hits in the last 30 days') }} : <span class="counter">{{ hits_last_30_days }}</span>
+</div>
+
 <table class="data-table">
     <caption class="sr-only">{{ _('Your list of published aids') }}</caption>
     <thead>
@@ -47,7 +52,7 @@
             <td>{{ aid.get_status_display }}</td>
             <td>
                 {% if aid.is_published %}
-                    {% get hits aid.slug 0 %}
+                    {% get hits_per_aid aid.slug 0 %}
                 {% endif %}
             </td>
         </tr>


### PR DESCRIPTION
https://trello.com/c/3ZUHpmMX/798-portefeuille-daide-nouveaux-indicateurs-dashboard

Modifications apportée : 
- 2 nouveaux indicateurs de nombre de vues s'affichent en haut du portefeuille d'aides

<img width="949" alt="Screenshot 2020-12-01 at 16 39 52" src="https://user-images.githubusercontent.com/7147385/100763068-017e7180-33f5-11eb-9969-deb84e79e544.png">
