### PR TITLE
Portefeuille d'aides : filtres par statut, état et affichage

### DIFF
--- a/src/aids/admin.py
+++ b/src/aids/admin.py
@@ -36,14 +36,16 @@ AIDS_EXPORT_EXCLUDE_FIELDS = [
 class LiveAidListFilter(admin.SimpleListFilter):
     """Custom admin filter to target aids with various statuses."""
 
-    title = _('Display status')
-    parameter_name = 'displayed'
+    title = _('State')
+    parameter_name = 'state'
 
     def lookups(self, request, model_admin):
         return (
+            # aid.state
             ('open', _('Open aids')),
+            ('deadline', _('Deadline approaching aids')),
             ('expired', _('Expired aids')),
-            ('deadline', _('Deadline approaching')),
+            # aid.display_status
             ('hidden', _('Currently not displayed')),
             ('live', _('Currently displayed')),
         )

--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -717,3 +717,29 @@ class AdvancedAidFilterForm(BaseAidSearchForm):
         required=False,
         choices=Aid.AUDIENCES,
         widget=forms.CheckboxSelectMultiple)
+
+
+class DraftListAidFilterForm(forms.Form):
+    """"""
+    AID_STATE_CHOICES = [
+        ('', ''),
+        ('open', _('Open')),
+        ('deadline', _('Deadline approaching')),
+        ('expired', _('Expired')),
+    ]
+
+    AID_DISPLAY_STATUS_CHOICES = [
+        ('', ''),
+        ('hidden', _('Not displayed')),
+        ('live', _('Displayed')),
+    ]
+
+    state = forms.ChoiceField(
+        label=_('State'),
+        required=False,
+        choices=AID_STATE_CHOICES)
+
+    display_status = forms.ChoiceField(
+        label=_('Display status'),
+        required=False,
+        choices=AID_DISPLAY_STATUS_CHOICES)

--- a/src/aids/models.py
+++ b/src/aids/models.py
@@ -54,7 +54,6 @@ class AidQuerySet(models.QuerySet):
           - the submission deadline is still in the future OR
           - the submission deadline is not provided OR
           - the recurrence field is set to "ongoing"
-
         """
 
         today = timezone.now().date()
@@ -90,6 +89,15 @@ class AidQuerySet(models.QuerySet):
             | (
                 Q(submission_deadline__lt=today)
                 & ~Q(recurrence='ongoing')))
+
+    def live(self):
+        """Returns the list of aids that appear on the frontend.
+
+        An aid is considered live if:
+          - the status is 'published'
+          - the aid is open (see open())
+        """
+        return self.published().open()
 
 
 class BaseExistingAidsManager(models.Manager):

--- a/src/aids/tests/test_managers.py
+++ b/src/aids/tests/test_managers.py
@@ -103,3 +103,36 @@ def test_hidden_filter(last_month, next_month):
     AidFactory(status='reviewable')
     AidFactory(status='published', submission_deadline=last_month)
     assert Aid.objects.hidden().count() == 3
+
+
+def test_live_filter(last_month, next_month):
+    """Test the `live` filter.
+
+    Aids only appear when they have the `published` status and are not
+    expired.
+    """
+
+    # Displayed aids
+    AidFactory(
+        status='published',
+        submission_deadline=timezone.now().date(),
+        recurrence='oneoff')
+    AidFactory(
+        status='published',
+        submission_deadline=next_month,
+        recurrence='oneoff')
+    AidFactory(
+        status='published',
+        submission_deadline=None,
+        recurrence='oneoff')
+    AidFactory(
+        status='published',
+        submission_deadline=next_month,
+        recurrence='ongoing')
+    assert Aid.objects.live().count() == 4
+
+    # Hidden aids
+    AidFactory(status='draft')
+    AidFactory(status='reviewable')
+    AidFactory(status='published', submission_deadline=last_month)
+    assert Aid.objects.live().count() == 4

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -138,23 +138,41 @@ msgstr "Vous êtes maintenant connecté·e. Bienvenue !"
 msgid "Your contributor profile was updated successfully."
 msgstr "Votre profil a été mise à jour."
 
-msgid "Display status"
-msgstr "Affichage"
+msgid "State"
+msgstr "État"
 
 msgid "Open aids"
 msgstr "Aides ouvertes"
 
+msgid "Deadline approaching aids"
+msgstr "Expirent bientôt"
+
 msgid "Expired aids"
 msgstr "Aides expirées"
 
+msgid "Open"
+msgstr "Ouverte"
+
 msgid "Deadline approaching"
-msgstr "Expirent bientôt"
+msgstr "Expire bientôt"
+
+msgid "Expired"
+msgstr "Expirée"
+
+msgid "Display status"
+msgstr "Affichage"
 
 msgid "Currently not displayed"
 msgstr "Actuellement non affichées"
 
 msgid "Currently displayed"
 msgstr "Actuellement affichées"
+
+msgid "Not displayed"
+msgstr "Non affichée"
+
+msgid "Displayed"
+msgstr "Affichée"
 
 msgid "Author"
 msgstr "Auteur"

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -1073,6 +1073,22 @@ article#draft-list {
             font-size: 125%;
         }
     }
+
+    .form-container {
+        select {
+            @extend .custom-select;
+            display: inline-block;
+            width: inherit;
+            border-radius: 0 1rem 1rem 1rem;
+            // border: none;
+        }
+        button.filter-btn {
+            @extend .btn;
+            @extend .btn-primary;
+            @extend .ml-3;
+            @include icon(before, $fa-var-search);
+        }
+    }
 }
 
 div#alert-modal {

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -1070,17 +1070,18 @@ article#draft-list {
             @extend .badge;
             @extend .badge-pill;
             @extend .badge-light;
-            font-size: 125%;
+            font-size: $font-size-base;
         }
     }
 
     .form-container {
         select {
             @extend .custom-select;
+            @extend .ml-2;
+            @extend .mr-3;
             display: inline-block;
             width: inherit;
             border-radius: 0 1rem 1rem 1rem;
-            // border: none;
         }
         button.filter-btn {
             @extend .btn;

--- a/src/templates/aids/draft_list.html
+++ b/src/templates/aids/draft_list.html
@@ -26,6 +26,15 @@
     {{ _('Number of hits in the last 30 days') }} : <span class="counter">{{ hits_last_30_days }}</span>
 </div>
 
+<form id="filter-form" action="" method="get" autocomplete='off'>
+    <div class="form-container">    
+        {{ filter_form }}
+        <button class="filter-btn" type="submit">
+            {{ _('Filter results') }}
+        </button>
+    </div>
+</form>
+
 <table class="data-table">
     <caption class="sr-only">{{ _('Your list of published aids') }}</caption>
     <thead>
@@ -40,15 +49,25 @@
     </thead>
     <tbody>
         {% for aid in aids %}
-        <tr {% if aid.has_expired %}class="expired"{% endif %}>
+        <tr>
             <td>
                 <a href="{% url 'aid_edit_view' aid.slug %}">
                     {{ aid.name|truncatechars:50 }}
                 </a>
+                {% if aid.is_live %}
+                    <span class="fas fa-check-circle" title="{{ _('Displayed') }}"></span>
+                {% endif %}
             </td>
             <td>{{ aid.date_created|date:'d/m/y' }}</td>
             <td>{{ aid.date_updated|date:'d/m/y' }}</td>
-            <td class="deadline">{{ aid.submission_deadline|date:'d/m/y' }}</td>
+            <td>
+                {% if aid.has_approaching_deadline %}
+                    <span class="fas fa-clock" title="{{ _('Deadline approaching') }}"></span>
+                {% elif aid.has_expired %}
+                    <span class="fas fa-exclamation-circle" title="{{ _('Expired') }}"></span>
+                {% endif %}
+                <span>{{ aid.submission_deadline|date:'d/m/y' }}</span>
+            </td>
             <td>{{ aid.get_status_display }}</td>
             <td>
                 {% if aid.is_published %}


### PR DESCRIPTION
https://trello.com/c/331qllvG/795-affichage-du-statut-de-laide-dans-le-portefeuille-daide

Modifications apportées : 
- ajout d'un formulaire de filtres en haut, qui permet de filtrer sur "l'état" et "l'affichage" des aides de son portefeuille
- Les 3 états possibles d'une aide sont : Ouverte, Expire bientôt (< 30 jours), Expirée
- Les 2 affichages possibles d'une aide sont : Non affichée, Affichée (= live)
- Ajout d'un icône dans la colonne Nom qui indique que l'aide est Affichée
- Ajout d'icônes dans la colonne Echéance qui indiquent que l'aide Expire bientôt ou est Expirée
- Ajout du queryset `open()` dans le modèle Aid (+ test)

![Screenshot 2020-12-04 at 16 00 57](https://user-images.githubusercontent.com/7147385/101178987-efe1d780-3649-11eb-922a-b0a6453c711e.png)

