### PR TITLE
Ajout de la page du porteur d'aide

### DIFF
--- a/src/backers/tests/test_views.py
+++ b/src/backers/tests/test_views.py
@@ -1,0 +1,15 @@
+"""Test backers views."""
+
+import pytest
+from django.urls import reverse
+
+from backers.factories import BackerFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_backer_details_page_loads(client, contributor):
+    backer = BackerFactory(name='Some Backer', slug='some-backer')
+    url = reverse('backer_detail_view', args=[backer.slug])
+    response = client.get(url)
+    assert response.status_code == 200

--- a/src/backers/urls.py
+++ b/src/backers/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+from backers.views import BackerDetailView
+
+
+urlpatterns = [
+    path(
+        '<slug:slug>/', BackerDetailView.as_view(),
+        name='backer_detail_view'),
+]

--- a/src/backers/views.py
+++ b/src/backers/views.py
@@ -1,0 +1,8 @@
+from django.views.generic import DetailView
+from backers.models import Backer
+
+
+class BackerDetailView(DetailView):
+    context_object_name = 'backer'
+    template_name = 'backers/detail.html'
+    queryset = Backer.objects.all()

--- a/src/core/urls.py
+++ b/src/core/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path('', include('home.urls')),
     path(_('accounts/'), include('accounts.urls')),
     path(_('aids/'), include('aids.urls')),
+    path(_('backers/'), include('backers.api.urls')),
     path(_('programs/'), include('programs.urls')),
     path(_('integration/'), include('integration.urls')),
     path(_('stats/'), include('stats.urls')),

--- a/src/core/urls.py
+++ b/src/core/urls.py
@@ -28,7 +28,7 @@ urlpatterns = [
     path('', include('home.urls')),
     path(_('accounts/'), include('accounts.urls')),
     path(_('aids/'), include('aids.urls')),
-    path(_('backers/'), include('backers.api.urls')),
+    path(_('backers/'), include('backers.urls')),
     path(_('programs/'), include('programs.urls')),
     path(_('integration/'), include('integration.urls')),
     path(_('stats/'), include('stats.urls')),

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-12-03 13:03+0100\n"
+"POT-Creation-Date: 2020-12-04 02:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1127,6 +1127,9 @@ msgstr "comptes/"
 
 msgid "aids/"
 msgstr "aides/"
+
+msgid "backers/"
+msgstr "financeurs/"
 
 msgid "programs/"
 msgstr "programmes/"

--- a/src/templates/backers/detail.html
+++ b/src/templates/backers/detail.html
@@ -1,0 +1,28 @@
+{% extends '_base.html' %}
+{% load compress %}
+
+{% block extratitle %}{{ backer.name }}{% endblock %}
+
+{% block breadcrumbs %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li><a href="{% url 'home' %}">{{ _('Home') }}</a></li>
+        <li class="active" aria-current="page">{{ backer.name }}</li>
+    </ol>
+</nav>
+{% endblock %}
+
+{% block content %}
+<article>
+<h1>{{ backer.name }}</h1>
+
+Description à faire
+
+</article>
+{% endblock %}
+
+{% block extra_js %}
+{% compress js %}
+<script src="/static/js/links_on_images.js"></script>
+{% endcompress %}
+{% endblock %}


### PR DESCRIPTION
Trello : https://trello.com/c/3AxE7y5S/825-ajouter-la-nouvelle-page-porteur-daide

Une page qui affiche la description du porteur d'aide.