### PR TITLE
create carousel to display backers-logos in Homepage

### DIFF
--- a/src/home/views.py
+++ b/src/home/views.py
@@ -27,7 +27,7 @@ class HomeView(TemplateView):
             .count()
         selected_backers = Backer.objects \
             .filter(Q(logo__isnull=False) & Q(is_spotlighted=True))
-        random_backers = selected_backers.order_by("?")[0:11]
+        random_backers = selected_backers.order_by("?")[0:12]
         
         context = super().get_context_data(**kwargs)
         context['nb_aids'] = aids_qs.values('id').count()

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -157,20 +157,44 @@
 
         div#logos {
             display: flex;
-            flex-direction: row;
             flex-wrap: wrap;
             justify-content: center;
-            margin-top: 2rem;
 
             a[href^="http"]::after {
                 display: none;
             }
-        }
 
-        img{
-            @extend .my-3;
-            @extend .mx-4;
-            max-height: 100px;
+            img {
+                @extend .my-3;
+                @extend .mx-4;
+                height: 100px;
+                max-width: 350px;
+                vertical-align: middle;
+            }
+
+            .hidden {
+                display: none;
+
+                a {
+                    display: none;
+
+                    img {
+                        display: none;
+                    }
+                }
+            }
+
+            .active {
+                display: block;
+
+                a {
+                    display: block;
+
+                    img {
+                        display: block;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/static/js/carousel.js
+++ b/src/static/js/carousel.js
@@ -1,0 +1,25 @@
+let logosIndex = 0;
+showLogos();
+
+function showLogos() {
+  let i;
+  let logo1 = document.getElementsByClassName("logo1");
+  let logo2 = document.getElementsByClassName("logo2");
+  let logo3 = document.getElementsByClassName("logo3");
+  
+  for (i = 0; i < logo1.length; i++) {
+	logo1[i].className = logo1[i].className.replace("active", "hidden");
+	logo2[i].className = logo2[i].className.replace("active", "hidden"); 
+	logo3[i].className = logo3[i].className.replace("active", "hidden");
+  }
+
+  logosIndex++;
+  if (logosIndex > logo1.length) {
+	  logosIndex = 1
+	}    
+	logo1[logosIndex-1].className = logo1[logosIndex-1].className.replace("hidden", "active");  
+	logo2[logosIndex-1].className = logo2[logosIndex-1].className.replace("hidden", "active");
+	logo3[logosIndex-1].className = logo3[logosIndex-1].className.replace("hidden", "active"); 
+
+  setTimeout(showLogos, 2500);
+}

--- a/src/templates/home/home.html
+++ b/src/templates/home/home.html
@@ -98,20 +98,31 @@
 </div>
 </section>
 
+{% if random_backers %}
 <section id="partner">
     <div class="container-lg">
         <h1>Les porteurs d'aides</h1>
         <div id="logos">
-            {% for random_backer in random_backers  %}
-            {% if random_backer.external_link%}
-                <a href="{{ random_backer.external_link }}">
-            {% else %}
-                <a href="#">
-            {% endif %}
-                    <img src="media/{{ random_backer.logo }}" alt="Logo : {{ random_backer.name }} ">
-                </a>
+            {% for random_backer in random_backers %}
+                <div class="{% cycle 'logo1' 'logo2' 'logo3' %} active">
+                    {% if random_backers.external_link%}
+                    <a href="{{ random_backer.external_link }}">
+                    {% else %}
+                    <a href="#">
+                    {% endif %}
+                        <img src="media/{{ random_backer.logo }}" alt="Logo : {{ random_backer.name }} ">
+                    </a>
+                </div>
             {% endfor %}
+            {% resetcycle %}
         </div>
     </div>
 </section>
+{% endif%}
+{% endblock %}
+
+{% block extra_js %}
+{% compress js %}
+<script src="/static/js/carousel.js"></script>
+{% endcompress js %}
 {% endblock %}


### PR DESCRIPTION
Complète la PR #295. 
Suite de la carte https://trello.com/c/q6gKEik3/628-simplification-de-laffichage-des-logos-sur-la-page-daccueil

Création d'un carousel pour afficher dynamiquement les logos des porteurs sur la page `Home`. 