### PR TITLE
Portefeuille d'aides : corrections à la marge

### DIFF
--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -735,7 +735,7 @@ class DraftListAidFilterForm(forms.Form):
     ]
 
     state = forms.ChoiceField(
-        label=_('State'),
+        label=_('Deadline'),
         required=False,
         choices=AID_STATE_CHOICES)
 

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -2234,10 +2234,10 @@ msgid "Suggest a modification"
 msgstr "Suggérer des modifications"
 
 msgid "Total number of hits"
-msgstr "Nombre de vues total des aides"
+msgstr "Nombre de vues total des aides depuis la première publication"
 
 msgid "Number of hits in the last 30 days"
-msgstr "Nombre de vues sur les 30 derniers jours"
+msgstr "Nombre de vues total des aides sur les 30 derniers jours"
 
 msgid "Your list of published aids"
 msgstr "La liste de vos aides publiées"

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -160,7 +160,7 @@ msgid "Expired"
 msgstr "Expirée"
 
 msgid "Display status"
-msgstr "Affichage"
+msgstr "Visibilité sur le site"
 
 msgid "Currently not displayed"
 msgstr "Actuellement non affichées"
@@ -621,6 +621,9 @@ msgstr "Le territoire"
 
 msgid "Order by"
 msgstr "Trier par"
+
+msgid "Click on the column name to order"
+msgstr "Cliquer sur le nom d'une colonne pour trier"
 
 msgid "This zipcode seems invalid"
 msgstr "Ce code postal semble invalide."
@@ -2243,7 +2246,7 @@ msgid "Created on"
 msgstr "Créée le"
 
 msgid "Last modified"
-msgstr "Dernière modif."
+msgstr "Modifiée le"
 
 msgid "Hits"
 msgstr "Vues"

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -1075,6 +1075,8 @@ article#draft-list {
     }
 
     .form-container {
+        margin-bottom: 1rem;
+
         select {
             @extend .custom-select;
             @extend .ml-2;
@@ -1089,6 +1091,11 @@ article#draft-list {
             @extend .ml-3;
             @include icon(before, $fa-var-search);
         }
+    }
+
+    .table-help {
+        @extend .float-right;
+        @extend .text-muted;
     }
 }
 

--- a/src/templates/aids/draft_list.html
+++ b/src/templates/aids/draft_list.html
@@ -65,19 +65,17 @@
                 <td>{{ aid.date_created|date:'d/m/y' }}</td>
                 <td>{{ aid.date_updated|date:'d/m/y' }}</td>
                 <td>
-                    {% if aid.has_approaching_deadline %}
+                    {% if aid.is_ongoing %}
+                        <span class="fas fa-parking" title="{{ _('Ongoing') }}"></span>
+                    {% elif aid.has_approaching_deadline %}
                         <span class="fas fa-clock" title="{{ _('Deadline approaching') }}"></span>
                     {% elif aid.has_expired %}
                         <span class="fas fa-exclamation-circle" title="{{ _('Expired') }}"></span>
                     {% endif %}
-                    <strong>{{ aid.submission_deadline|date:'d/m/y' }}</strong>
+                    <span>{{ aid.submission_deadline|date:'d/m/y' }}</span>
                 </td>
                 <td>{{ aid.get_status_display }}</td>
-                <td>
-                    {% if aid.is_published %}
-                        {% get hits_per_aid aid.slug 0 %}
-                    {% endif %}
-                </td>
+                <td>{% get hits_per_aid aid.slug 0 %}</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/src/templates/aids/draft_list.html
+++ b/src/templates/aids/draft_list.html
@@ -15,70 +15,75 @@
 {% block content %}
 <article id="draft-list">
 
-<a class="main-action action-add" href="{% url 'aid_create_view' %}">
-    {{ _('Publish a new aid') }}
-</a>
+    <a class="main-action action-add" href="{% url 'aid_create_view' %}">
+        {{ _('Publish a new aid') }}
+    </a>
 
-<h1>{{ _('My portfolio') }}</h1>
+    <h1>{{ _('My portfolio') }}</h1>
 
-<div class="info">
-    {{ _('Total number of hits') }} : <span class="counter">{{ hits_total }}</span><br />
-    {{ _('Number of hits in the last 30 days') }} : <span class="counter">{{ hits_last_30_days }}</span>
-</div>
-
-<form id="filter-form" action="" method="get" autocomplete='off'>
-    <div class="form-container">    
-        {{ filter_form }}
-        <button class="filter-btn" type="submit">
-            {{ _('Filter results') }}
-        </button>
+    <div class="info">
+        {{ _('Total number of hits') }} : <span class="counter">{{ hits_total }}</span><br />
+        {{ _('Number of hits in the last 30 days') }} : <span class="counter">{{ hits_last_30_days }}</span>
     </div>
-</form>
 
-<table class="data-table">
-    <caption class="sr-only">{{ _('Your list of published aids') }}</caption>
-    <thead>
-        <tr>
-            <th>{% sortable_header _('Aid title') 'name' %}</th>
-            <th>{% sortable_header _('Created on') 'date_created' %}</th>
-            <th>{% sortable_header _('Last modified') 'date_updated' %}</th>
-            <th>{% sortable_header _('Deadline') 'submission_deadline' %}</th>
-            <th>{% sortable_header _('Status') 'status' %}</th>
-            <th>{{ _('Hits') }}</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for aid in aids %}
-        <tr>
-            <td>
-                <a href="{% url 'aid_edit_view' aid.slug %}">
-                    {{ aid.name|truncatechars:50 }}
-                </a>
-                {% if aid.is_live %}
-                    <span class="fas fa-check-circle" title="{{ _('Displayed') }}"></span>
-                {% endif %}
-            </td>
-            <td>{{ aid.date_created|date:'d/m/y' }}</td>
-            <td>{{ aid.date_updated|date:'d/m/y' }}</td>
-            <td>
-                {% if aid.has_approaching_deadline %}
-                    <span class="fas fa-clock" title="{{ _('Deadline approaching') }}"></span>
-                {% elif aid.has_expired %}
-                    <span class="fas fa-exclamation-circle" title="{{ _('Expired') }}"></span>
-                {% endif %}
-                <span>{{ aid.submission_deadline|date:'d/m/y' }}</span>
-            </td>
-            <td>{{ aid.get_status_display }}</td>
-            <td>
-                {% if aid.is_published %}
-                    {% get hits_per_aid aid.slug 0 %}
-                {% endif %}
-            </td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
+    <form id="filter-form" action="" method="get" autocomplete='off'>
+        <div class="form-container">    
+            {{ filter_form }}
+            <button class="filter-btn" type="submit">
+                {{ _('Filter results') }}
+            </button>
+        </div>
+    </form>
+    
+    <div class="table-help">
+        {{ _('Click on the column name to order') }}
+    </div>
 
-{% include '_pagination.html' %}
+    <table class="data-table">
+        <caption class="sr-only">{{ _('Your list of published aids') }}</caption>
+        <thead>
+            <tr>
+                <th title="{{ _('Order by') }} {{ _('Aid title') }}">{% sortable_header _('Aid title') 'name' %}</th>
+                <th title="{{ _('Order by') }} {{ _('Created on') }}">{% sortable_header _('Created on') 'date_created' %}</th>
+                <th title="{{ _('Order by') }} {{ _('Last modified') }}">{% sortable_header _('Last modified') 'date_updated' %}</th>
+                <th title="{{ _('Order by') }} {{ _('Deadline') }}">{% sortable_header _('Deadline') 'submission_deadline' %}</th>
+                <th title="{{ _('Order by') }} {{ _('Status') }}">{% sortable_header _('Status') 'status' %}</th>
+                <th>{{ _('Hits') }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for aid in aids %}
+            <tr>
+                <td>
+                    <a href="{% url 'aid_edit_view' aid.slug %}">
+                        {{ aid.name|truncatechars:50 }}
+                    </a>
+                    {% if aid.is_live %}
+                        <span class="fas fa-check-circle" title="{{ _('Displayed') }}"></span>
+                    {% endif %}
+                </td>
+                <td>{{ aid.date_created|date:'d/m/y' }}</td>
+                <td>{{ aid.date_updated|date:'d/m/y' }}</td>
+                <td>
+                    {% if aid.has_approaching_deadline %}
+                        <span class="fas fa-clock" title="{{ _('Deadline approaching') }}"></span>
+                    {% elif aid.has_expired %}
+                        <span class="fas fa-exclamation-circle" title="{{ _('Expired') }}"></span>
+                    {% endif %}
+                    <strong>{{ aid.submission_deadline|date:'d/m/y' }}</strong>
+                </td>
+                <td>{{ aid.get_status_display }}</td>
+                <td>
+                    {% if aid.is_published %}
+                        {% get hits_per_aid aid.slug 0 %}
+                    {% endif %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    {% include '_pagination.html' %}
+
 </article>
 {% endblock %}


### PR DESCRIPTION
Dans la continuité de https://github.com/MTES-MCT/aides-territoires/pull/292

Modifications apportées : 
- Renomage de certains labels
- Ajout d'un message pour indiquer que les colonnes sont triables + ajout de `title=` sur le nom des colonnes
- Ajout d'un icône "P" dans la colonne Échéance pour indiquer les aides permanentes
- Afficher tout le temps le nombre de vues par aide (avant : seulement si l'aide était au Statut publiée)
- Ajustement du formattage du code html 😅 