### PR TITLE
Edition d'une aide - correction à la marge

### DIFF
--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -411,7 +411,7 @@ class AidEditView(ContributorRequiredMixin, MessageMixin, AidEditMixin,
 
     def get_success_url(self):
         edit_url = reverse('aid_edit_view', args=[self.object.slug])
-        return '{}?preview'.format(edit_url)
+        return '{}'.format(edit_url)
 
 
 class AidStatusUpdate(ContributorRequiredMixin, AidEditMixin,

--- a/src/static/css/_globals.scss
+++ b/src/static/css/_globals.scss
@@ -725,6 +725,7 @@ p, div {
 
     &.warning {
         @extend .alert-warning;
+        font-weight: bold;
     }
 
     &.tip {


### PR DESCRIPTION
Correction pour mise en prod de la carte https://trello.com/c/xYhIRrU7/794-option-d%C3%A9ditions-dune-aide

Auparavant, lorsque l'utilisateur cliquait sur le bouton `dupliquer l'aide` il était renvoyé sur la page d'édition de la nouvelle aide et l'iframe de prévisualisation de l'aide apparaissait automatiquement. On supprime ce comportement pour que l'utilisateur soit renvoyée vers la page d'édition de la nouvelle aide sans prévisualisation. 

`Font-weight: bold` pour le `<p>` warning indiquant que la nouvelle aide a été créée. 