### PR TITLE
Conditionne l'affichage du titre "critères d'éligibilité" sur la page AidDetail

### DIFF
--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -261,6 +261,11 @@ class AidDetailView(DetailView):
             'instructors': instructors,
         })
 
+        if self.object.mobilization_steps or self.object.destinations \
+        or self.object.project_examples or self.object.eligibility:
+            eligibility_criteria = True
+            context['eligibility_criteria'] = eligibility_criteria
+
         return context
 
     def get(self, request, *args, **kwargs):

--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -261,10 +261,11 @@ class AidDetailView(DetailView):
             'instructors': instructors,
         })
 
-        if self.object.mobilization_steps or self.object.destinations \
-        or self.object.project_examples or self.object.eligibility:
-            eligibility_criteria = True
-            context['eligibility_criteria'] = eligibility_criteria
+        context['eligibility_criteria'] = any((
+            self.object.mobilization_steps,
+            self.object.destinations,
+            self.object.project_examples,
+            self.object.eligibility))
 
         return context
 

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -205,7 +205,9 @@
             <h3>{{ _('Aid targeted area') }}</h3>
             <p>{{ aid.perimeter }}</p>
 
+            {% if aid.mobilization_steps or aid.destinations or aid.project_examples or aid.eligibility%}
             <h2>{{ _('Eligibility criteria') }}</h2>
+            {% endif %}
 
             {% if aid.mobilization_steps %}
                 <h3>{{ _('The aid can be mobilized during…') }}</h3>

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -205,7 +205,7 @@
             <h3>{{ _('Aid targeted area') }}</h3>
             <p>{{ aid.perimeter }}</p>
 
-            {% if aid.mobilization_steps or aid.destinations or aid.project_examples or aid.eligibility %}
+            {% if eligibility_criteria %}
             <h2>{{ _('Eligibility criteria') }}</h2>
 
                 {% if aid.mobilization_steps %}

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -207,28 +207,28 @@
 
             {% if aid.mobilization_steps or aid.destinations or aid.project_examples or aid.eligibility %}
             <h2>{{ _('Eligibility criteria') }}</h2>
-            {% endif %}
 
-            {% if aid.mobilization_steps %}
-                <h3>{{ _('The aid can be mobilized during…') }}</h3>
-                <p>{% choices_display aid 'mobilization_steps' %}</p>
-            {% endif %}
+                {% if aid.mobilization_steps %}
+                    <h3>{{ _('The aid can be mobilized during…') }}</h3>
+                    <p>{% choices_display aid 'mobilization_steps' %}</p>
+                {% endif %}
 
-            {% if aid.destinations %}
-                <h3>{{ _('Types of expenses covered') }}</h3>
-                <p>{% choices_display aid 'destinations' %}</p>
-            {% endif %}
+                {% if aid.destinations %}
+                    <h3>{{ _('Types of expenses covered') }}</h3>
+                    <p>{% choices_display aid 'destinations' %}</p>
+                {% endif %}
 
-            {% if aid.project_examples %}
-                <h3>{{ _('Project examples') }}</h3>
-                {{ aid.project_examples|safe }}
-            {% endif %}
+                {% if aid.project_examples %}
+                    <h3>{{ _('Project examples') }}</h3>
+                    {{ aid.project_examples|safe }}
+                {% endif %}
 
-            {% if aid.eligibility %}
-                <h3>{{ _('Other eligibility criterias') }}</h3>
-                {{ aid.eligibility|safe }}
+                {% if aid.eligibility %}
+                    <h3>{{ _('Other eligibility criterias') }}</h3>
+                    {{ aid.eligibility|safe }}
+                {% endif %}
             {% endif %}
-
+            
             <div id="going-further">
                 <h2>{{ _('Going further') }}</h2>
 

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -205,7 +205,7 @@
             <h3>{{ _('Aid targeted area') }}</h3>
             <p>{{ aid.perimeter }}</p>
 
-            {% if aid.mobilization_steps or aid.destinations or aid.project_examples or aid.eligibility%}
+            {% if aid.mobilization_steps or aid.destinations or aid.project_examples or aid.eligibility %}
             <h2>{{ _('Eligibility criteria') }}</h2>
             {% endif %}
 


### PR DESCRIPTION
https://trello.com/c/jFmspMsa/815-fiche-aide-affichage-crit%C3%A8res-d%C3%A9ligibilit%C3%A9

Conditionne l'affichage du `h2` "critères d'éligibilité" à la présence d'un de ces champs : 
-  `mobilization_steps`
- `destinations `
- `project_examples` 
- `eligibility`
