### PR TITLE
Corrige un bug de sélection des catégories

### DIFF
--- a/src/minisites/mixins.py
+++ b/src/minisites/mixins.py
@@ -48,6 +48,7 @@ class NarrowedFiltersMixin:
         if not hasattr(self, 'available_categories'):
             page_categories = self.search_page \
                 .available_categories \
+                .order_by('theme__name', 'name') \
                 .select_related('theme')
             self.available_categories = page_categories
         return self.available_categories


### PR DESCRIPTION
https://trello.com/c/tWraMYk1/832-bug-affichage-cat%C3%A9gories

Une même thématique pouvait s'afficher plusieurs fois dans le champ de filtrage par catégories.