### PR TITLE
Rend obligatoire le choix d'une thématique pour la création d'une aide

### DIFF
--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -332,6 +332,8 @@ class AidEditForm(BaseAidForm):
             range_widgets[1].attrs['placeholder'] = _('Max. subvention rate')
         if 'mobilization_steps' in self.fields:
             self.fields['mobilization_steps'].required = True
+        if 'categories' in self.fields:
+            self.fields['categories'].required = True
 
     def clean(self):
         """Validation routine (frontend form only)."""


### PR DESCRIPTION
https://trello.com/c/wjvbBYRf/834-rendre-obligatoire-le-choix-dune-th%C3%A9matique-dans-le-formulaire-de-cr%C3%A9ation-daide

Il était possible de créer une aide sans choisir de thématique. 