### PR TITLE
Correction de l'affichage du message lors de la création d'une aide

### DIFF
--- a/src/templates/aids/edit.html
+++ b/src/templates/aids/edit.html
@@ -22,7 +22,7 @@
         {% for message in messages %}
         <p class="warning">
             <span class="fas fa-exclamation-circle"></span>
-            {{ message }}
+            {{ message | safe }}
         </p>
     {% endfor %}
     {% endif %}


### PR DESCRIPTION
La balise <a> du message affiché lors de la création d'une aide par un porteur était échappée. 

https://trello.com/c/O7S4nUcE/836-bug-notification-aide-publi%C3%A9e