### PR TITLE
Préfixe le titre des aides dupliquées en admin

### DIFF
--- a/src/aids/admin.py
+++ b/src/aids/admin.py
@@ -7,6 +7,7 @@ from django.contrib import admin
 from django.contrib.admin.views.main import ChangeList
 from django.urls import path
 from django.utils.translation import ugettext_lazy as _
+from django.utils import timezone
 from django.urls import reverse
 
 from import_export import fields, resources
@@ -15,6 +16,7 @@ from import_export.formats import base_formats
 from import_export.widgets import ForeignKeyWidget, ManyToManyWidget
 from admin_auto_filters.filters import AutocompleteFilter
 
+from aids.utils import generate_clone_title
 from aids.admin_views import AmendmentMerge
 from aids.forms import AidAdminForm
 from aids.models import Aid
@@ -370,6 +372,13 @@ class AidAdmin(BaseAidAdmin):
 
     def delete_queryset(self, request, queryset):
         queryset.update(status='deleted')
+
+    def save_model(self, request, obj, form, change):
+
+        # When cloning an existing aid, prefix it's title with "[Copie]"
+        if '_saveasnew' in request.POST:
+            obj.name = generate_clone_title(obj.name)
+        return super().save_model(request, obj, form, change)
 
 
 class DeletedAid(Aid):

--- a/src/aids/tests/test_utils.py
+++ b/src/aids/tests/test_utils.py
@@ -1,0 +1,18 @@
+import pytest
+from datetime import datetime
+
+from aids.utils import generate_clone_title
+
+clone_tests = [
+    ('Aid title', '[Copie 10h42] Aid title'),
+    ('[Copie 10h20] Aid title', '[Copie 10h42] Aid title'),
+    ('[Copie] Aid title', '[Copie 10h42] Aid title'),
+    ('[Portnawak] Aid title', '[Copie 10h42] [Portnawak] Aid title'),
+]
+
+
+@pytest.mark.parametrize('title,clone_title', clone_tests)
+def test_generate_clone_title(title, clone_title):
+
+    test_timestamp = datetime(year=2020, month=1, day=1, hour=10, minute=42)
+    assert generate_clone_title(title, now=test_timestamp) == clone_title

--- a/src/aids/utils.py
+++ b/src/aids/utils.py
@@ -1,0 +1,27 @@
+import re
+
+from django.utils import timezone
+
+
+# The regex to detect existing title prefixes for duplicate aids
+CLONE_PREFIX_RE = r'^\[Copie( \d{2}h\d{2})?\] '
+#                   ^                           | Starts with...
+#                    \[Copie               \]   | the string "[Copie] "...
+#                           (            )?     | containing an optional...
+#                             \d{2}h\d{2}       | H:M timestamp
+
+
+def generate_clone_title(aid_title, now=None):
+    """Return a suitable name for a duplicate aid.
+
+    >>> generate_clone_name('Aid title')
+    [Copie 10h04] Aid title]
+
+    >>> generate_clone_name('[Copie 10h04] Aid title')
+    [Copie 10h05] Aid title]
+    """
+    now = now or timezone.now()
+
+    title_without_prefix = re.sub(CLONE_PREFIX_RE, r'', aid_title)
+    new_title = f'[Copie {now:%Hh%M}] {title_without_prefix}'
+    return new_title


### PR DESCRIPTION
https://trello.com/c/SFH4ni06/838-duplication-daide-identifier-les-aides-dupliqu%C3%

Pour tester, éditer une aide dans l'admin, et cliquer sur « Enregistrer en tant que nouveau ». Constater le titre de la nouvelle aide ainsi créée.