### PR TITLE
Portefeuille d'aides : nouvelle colonne périmètre

### DIFF
--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -286,6 +286,7 @@ class AidDraftListView(ContributorRequiredMixin, AidEditMixin, ListView):
     paginate_by = 50
     sortable_columns = [
         'name',
+        'perimeter__name',
         'date_created',
         'date_updated',
         'submission_deadline',

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -1130,6 +1130,12 @@ article#draft-list {
         @extend .float-right;
         @extend .text-muted;
     }
+
+    table {
+        th.aid-name-column {
+            width: 50%;
+        }
+    }
 }
 
 div#alert-modal {

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -1132,8 +1132,12 @@ article#draft-list {
     }
 
     table {
-        th.aid-name-column {
-            width: 50%;
+        th {
+            white-space: nowrap;
+        }
+        td.aid-deadline-cell,
+        td.aid-status-cell {
+            white-space: nowrap;
         }
     }
 }

--- a/src/templates/aids/draft_list.html
+++ b/src/templates/aids/draft_list.html
@@ -66,7 +66,7 @@
                 <td>{{ aid.perimeter }}</td>
                 <td>{{ aid.date_created|date:'d/m/y' }}</td>
                 <td>{{ aid.date_updated|date:'d/m/y' }}</td>
-                <td>
+                <td class="aid-deadline-cell">
                     {% if aid.is_ongoing %}
                         <span class="fas fa-parking" title="{{ _('Ongoing') }}"></span>
                     {% elif aid.has_approaching_deadline %}
@@ -76,7 +76,7 @@
                     {% endif %}
                     <span>{{ aid.submission_deadline|date:'d/m/y' }}</span>
                 </td>
-                <td>{{ aid.get_status_display }}</td>
+                <td class="aid-status-cell">{{ aid.get_status_display }}</td>
                 <td>{% get hits_per_aid aid.slug 0 %}</td>
             </tr>
             {% endfor %}

--- a/src/templates/aids/draft_list.html
+++ b/src/templates/aids/draft_list.html
@@ -43,7 +43,8 @@
         <caption class="sr-only">{{ _('Your list of published aids') }}</caption>
         <thead>
             <tr>
-                <th title="{{ _('Order by') }} {{ _('Aid title') }}">{% sortable_header _('Aid title') 'name' %}</th>
+                <th class="aid-name-column" title="{{ _('Order by') }} {{ _('Aid title') }}">{% sortable_header _('Aid title') 'name' %}</th>
+                <th title="{{ _('Order by') }} {{ _('Perimeter') }}">{% sortable_header _('Perimeter') 'perimeter__name' %}</th>
                 <th title="{{ _('Order by') }} {{ _('Created on') }}">{% sortable_header _('Created on') 'date_created' %}</th>
                 <th title="{{ _('Order by') }} {{ _('Last modified') }}">{% sortable_header _('Last modified') 'date_updated' %}</th>
                 <th title="{{ _('Order by') }} {{ _('Deadline') }}">{% sortable_header _('Deadline') 'submission_deadline' %}</th>
@@ -56,12 +57,13 @@
             <tr>
                 <td>
                     <a href="{% url 'aid_edit_view' aid.slug %}">
-                        {{ aid.name|truncatechars:50 }}
+                        {{ aid.name }}
                     </a>
                     {% if aid.is_live %}
                         <span class="fas fa-check-circle" title="{{ _('Displayed') }}"></span>
                     {% endif %}
                 </td>
+                <td>{{ aid.perimeter }}</td>
                 <td>{{ aid.date_created|date:'d/m/y' }}</td>
                 <td>{{ aid.date_updated|date:'d/m/y' }}</td>
                 <td>


### PR DESCRIPTION
https://trello.com/c/HtAr5f9O/840-portefeuille-daide-affichage-p%C3%A9rim%C3%A9tres
https://trello.com/c/9sxm8ayV/842-portefeuille-daide-titre-aide

Modifications apportées : 
- Nouvelle colonne qui affiche le périmètre de l'aide, avec possibilité d'ordonner par cette colonne
- Afficher le Nom complet de l'aide, donc il y aura parfois un retour à la ligne
- La largeur de la colonne Nom est fixée à 50%

![Screenshot 2020-12-14 at 16 26 29](https://user-images.githubusercontent.com/7147385/102110723-cc7f0f80-3e35-11eb-831f-28fbb9a9b8b4.png)
