### PR TITLE
Modifie la construction de l'url des images

### DIFF
--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -195,7 +195,7 @@
                 {% for program in programs %}
                     {% if program.logo %}
                     <a href="{% url 'program_detail' program.slug %}">
-                        <img src="{{ program.logo }}" alt="{{ program.name }}">
+                        <img src="{{ program.logo.url }}" alt="{{ program.name }}">
                     </a>
                     {% endif %}
                 {% endfor %}

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -203,7 +203,7 @@
                 {% for financer in financers %}
                 {% if financer.logo %}
                 <a href="#">
-                    <img src="{{ financer.logo }}" alt="{{ financer.name }}">
+                    <img src="{{ financer.logo.url }}" alt="{{ financer.name }}">
                 </a>
                 {% endif %}
                 {% endfor %}


### PR DESCRIPTION
Sur la page AidDetail l'url des images n'était pas construite correctement. 