### PR TITLE
Minisites : meilleur gestion des stats renvoyées par Matomo

### DIFF
--- a/src/aids/admin.py
+++ b/src/aids/admin.py
@@ -7,7 +7,6 @@ from django.contrib import admin
 from django.contrib.admin.views.main import ChangeList
 from django.urls import path
 from django.utils.translation import ugettext_lazy as _
-from django.utils import timezone
 from django.urls import reverse
 
 from import_export import fields, resources

--- a/src/minisites/views.py
+++ b/src/minisites/views.py
@@ -164,27 +164,27 @@ class SiteStats(MinisiteMixin, TemplateView):
         )
 
         # view count: all-time
-        data = get_matomo_stats_from_page_title(
+        context['view_count_total'] = get_matomo_stats_from_page_title(
             page_title=self.search_page.meta_title or self.search_page.title,
-            from_date_string=self.search_page.date_created.strftime('%Y-%m-%d')
+            from_date_string=self.search_page.date_created.strftime('%Y-%m-%d'),  # noqa
+            result_key='nb_hits'
         )
-        context['view_count_total'] = data['nb_hits']
 
         # view count: last 30 days
         from_date = timezone.now() - timedelta(days=30)
-        data = get_matomo_stats_from_page_title(
+        context['view_count_last_30_days'] = get_matomo_stats_from_page_title(
             page_title=self.search_page.meta_title or self.search_page.title,
-            from_date_string=from_date.strftime('%Y-%m-%d')
+            from_date_string=from_date.strftime('%Y-%m-%d'),
+            result_key='nb_hits'
         )
-        context['view_count_last_30_days'] = data['nb_hits']
 
         # view count: last 7 days
         from_date = timezone.now() - timedelta(days=7)
-        data = get_matomo_stats_from_page_title(
+        context['view_count_last_7_days'] = get_matomo_stats_from_page_title(
             page_title=self.search_page.meta_title or self.search_page.title,
-            from_date_string=from_date.strftime('%Y-%m-%d')
+            from_date_string=from_date.strftime('%Y-%m-%d'),
+            result_key='nb_hits'
         )
-        context['view_count_last_7_days'] = data['nb_hits']
 
         return context
 

--- a/src/stats/utils.py
+++ b/src/stats/utils.py
@@ -17,7 +17,7 @@ def log_event(category, event, meta='', value=None):
 
 
 @lru_cache()
-def get_matomo_stats_from_page_title(page_title, from_date_string, to_date_string=timezone.now().strftime('%Y-%m-%d')):  # noqa
+def get_matomo_stats_from_page_title(page_title, from_date_string, to_date_string=timezone.now().strftime('%Y-%m-%d'), result_key='nb_hits'):  # noqa
     """
     Get view stats of a Page Title from Matomo.
     From_date_string & to_date_string must have YYYY-MM-DD format.
@@ -34,4 +34,8 @@ def get_matomo_stats_from_page_title(page_title, from_date_string, to_date_strin
     res = requests.get(matomo_page_title_base_url)
     data = res.json()
 
-    return data[0]
+    try:
+        return data[0][result_key]
+    except KeyError:
+        # most likely an error or missing information in the url
+        return 0


### PR DESCRIPTION
Dans certains environments (staging, local), on a pas les infos nécessaires pour échanger avec Matomo. Du coup afficher 0 pour ces stats là. Cela faisait planter la page stats des minisites sinon.

Bug Sentry en staging : https://sentry.io/organizations/aides-territoires-beta/issues/2093983588/?project=5506818&referrer=slack