### PR TITLE
Affichage du commentaire sur le taux de subvention sur les Fiches Aide

### DIFF
--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -121,9 +121,10 @@
                     <p>{% choices_display aid 'aid_types' %}</p>
                 </div>
 
-                {% if aid.subvention_rate %}
+                {% if aid.subvention_rate or aid.subvention_comment %}
                     <div class="subvention-rate">
                         <h3>{{ _('Subvention rate') }}</h3>
+                        {% if aid.subvention_rate %}
                         <ul>
                             {% if aid.subvention_rate.lower %}
                                 <li><strong>{{ _('Min:') }}</strong> {{ aid.subvention_rate.lower }}%</li>
@@ -132,6 +133,7 @@
                                 <li><strong>{{ _('Max:') }}</strong> {{ aid.subvention_rate.upper }}%</li>
                             {% endif %}
                         </ul>
+                        {% endif %}
                         {% if aid.subvention_comment %}
                             {{ aid.subvention_comment }}
                         {% endif %}


### PR DESCRIPTION
Le commentaire sur le taux de subvention ne pouvait s'afficher que si un taux de subvention était renseigné. 

https://trello.com/c/urRtPPYT/850-affichage-du-commentaire-sur-le-taux-de-subvention-sur-la-fiche-aide 