### PR TITLE
Modification du champ AAP/AMI dans le cartouche "plus de critères"

### DIFF
--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -451,7 +451,7 @@ class BaseAidSearchForm(forms.Form):
         required=False,
         choices=Aid.RECURRENCE)
     call_for_projects_only = forms.BooleanField(
-        label=_('Call for projects only (AAP) / Call for investment interests only (AMI)'),
+        label=_('Call for projects only'),
         required=False)
     backers = AutocompleteModelMultipleChoiceField(
         label=_('Backers'),

--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -451,7 +451,7 @@ class BaseAidSearchForm(forms.Form):
         required=False,
         choices=Aid.RECURRENCE)
     call_for_projects_only = forms.BooleanField(
-        label=_('Call for projects only'),
+        label=_('Call for projects only (AAP) / Call for investment interests only (AMI)'),
         required=False)
     backers = AutocompleteModelMultipleChoiceField(
         label=_('Backers'),

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -584,7 +584,7 @@ msgid "Recurrence"
 msgstr "Récurrence"
 
 msgid "Call for projects only"
-msgstr "Appels à projets (AAP) / Appels à manifestation d’intérêt (AMI) uniquement"
+msgstr "Appels à projets / Appels à manifestation d’intérêt uniquement"
 
 msgid "Aid programs"
 msgstr "Programmes d'aides"

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -584,9 +584,6 @@ msgid "Recurrence"
 msgstr "Récurrence"
 
 msgid "Call for projects only"
-msgstr "AAP / AMI uniquement"
-
-msgid "Call for projects only (AAP) / Call for investment interests only (AMI)"
 msgstr "Appels à projets (AAP) / Appels à manifestation d’intérêt (AMI) uniquement"
 
 msgid "Aid programs"

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -586,6 +586,9 @@ msgstr "Récurrence"
 msgid "Call for projects only"
 msgstr "AAP / AMI uniquement"
 
+msgid "Call for projects only (AAP) / Call for investment interests only (AMI)"
+msgstr "Appels à projets (AAP) / Appels à manifestation d’intérêt (AMI) uniquement"
+
 msgid "Aid programs"
 msgstr "Programmes d'aides"
 

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -269,11 +269,15 @@ section#search-engine {
 
         div.form-check-inline {
             align-items: baseline;
-            margin-bottom: 1rem;
             font-weight: bold;
 
             input[type=checkbox] {
                 margin-right: 0.5rem;
+                margin-bottom: 2rem;
+            }
+
+            label {
+                margin: 0;
             }
         }
 

--- a/src/templates/aids/_search_form.html
+++ b/src/templates/aids/_search_form.html
@@ -63,7 +63,9 @@
 
                 <div class="form-check form-check-inline">
                     {{ form.call_for_projects_only }}
-                    <label>{{ form.call_for_projects_only.label }}</label>
+                    <label>
+                        {{ form.call_for_projects_only.label }}
+                    </label>
                 </div>
             </div>
 

--- a/src/templates/aids/_search_form.html
+++ b/src/templates/aids/_search_form.html
@@ -61,9 +61,9 @@
                     </div> 
                     {% endfor %}
 
-                <div class="form-group checkbox-group">
+                <div class="form-check form-check-inline">
                     {{ form.call_for_projects_only }}
-                    <label>{% blocktrans %}Call for projects only{% endblocktrans %}</label>
+                    <label>{{ form.call_for_projects_only.label }}</label>
                 </div>
             </div>
 

--- a/src/templates/aids/_search_form.html
+++ b/src/templates/aids/_search_form.html
@@ -63,9 +63,7 @@
 
                 <div class="form-group checkbox-group">
                     {{ form.call_for_projects_only }}
-                    <label>
-                        {{ form.call_for_projects_only.label }}
-                    </label>
+                    <label>{% blocktrans %}Call for projects only{% endblocktrans %}</label>
                 </div>
             </div>
 


### PR DESCRIPTION
https://trello.com/c/CRzbM0ZQ/732-changement-de-texte-cartouche-plus-de-crit%C3%A8res

Dans le formulaire "plus de critères" on remplace le champ `AAP / AMI uniquement` par `Appels à projets / Appels à manifestation d’intérêt uniquement`