### PR TITLE
Porteurs d'aides : Améliorations de la gestion des logos

### DIFF
--- a/src/backers/models.py
+++ b/src/backers/models.py
@@ -1,6 +1,7 @@
 from os.path import splitext
 
 from django.db import models
+from django.db.models import Q
 from django.db.models.expressions import RawSQL
 from django.utils import timezone
 from django.utils.text import slugify
@@ -70,6 +71,17 @@ class BackerQuerySet(models.QuerySet):
         qs = self.filter(financed_aids__status=AidWorkflow.states.published) \
             .distinct()
         return qs
+
+    def has_logo(self):
+        """Only return backers with a logo."""
+
+        return self.exclude(Q(logo='') | Q(logo=None))
+
+    def can_be_displayed_in_carousel(self):
+        """Only return spotlighted backers with a logo."""
+
+        return self.filter(is_spotlighted=True) \
+            .has_logo()
 
     def annotate_aids_count(self, related_fields, annotation_name):
         """Annotate the queryset with the number of related aids.
@@ -176,3 +188,6 @@ class Backer(models.Model):
     def save(self, *args, **kwargs):
         self.set_slug()
         return super().save(*args, **kwargs)
+
+    def has_logo(self):
+        return bool(self.logo.name)

--- a/src/home/views.py
+++ b/src/home/views.py
@@ -25,16 +25,15 @@ class HomeView(TemplateView):
             .filter(Q(id__in=financers) | Q(id__in=instructors)) \
             .values('id') \
             .count()
-        selected_backers = Backer.objects.filter(
-            logo__isnull=False,
-            is_spotlighted=True)
-        # We only display the first 12
-        random_backers = selected_backers.order_by("?")[0:15]
+        selected_backers = Backer.objects.can_be_displayed_in_carousel()
+        # We only display the first 15
+        subset_selected_backers = selected_backers.order_by("?")[0:15]
+        print(subset_selected_backers)
         context = super().get_context_data(**kwargs)
         context['nb_aids'] = aids_qs.values('id').count()
         context['nb_categories'] = Category.objects.all().count()
         context['nb_backers'] = nb_backers
-        context['random_backers'] = random_backers
+        context['subset_selected_backers'] = subset_selected_backers
 
         return context
 

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -193,7 +193,7 @@ msgid "Is a corporate backer?"
 msgstr "Porteur d'aides privé ?"
 
 msgid "Is a spotlighted backer?"
-msgstr "Le porteur est-il mis en avant?"
+msgstr "Le porteur est-il mis en avant ?"
 
 msgid "If the backer is spotlighted, its logo appears in the HomePage"	
 msgstr ""	

--- a/src/static/js/carousel.js
+++ b/src/static/js/carousel.js
@@ -1,31 +1,35 @@
-let logosIndex = 0;
+// init
+const logoIdList = ["logo1", "logo2", "logo3", "logo4", "logo5"];
+let carousel = {};
+let currentIndex = 0;
 showLogos();
 
+/**
+ * Display up to 5 backer logos at the same time
+ * Replace them every 4 seconds
+ */
 function showLogos() {
-  let i;
-  let logo1 = document.getElementsByClassName("logo1");
-  let logo2 = document.getElementsByClassName("logo2");
-  let logo3 = document.getElementsByClassName("logo3");
-  let logo4 = document.getElementsByClassName("logo4");
-  let logo5 = document.getElementsByClassName("logo5");
-  
-  for (i = 0; i < logo1.length; i++) {
-	logo1[i].className = logo1[i].className.replace("active", "hidden");
-	logo2[i].className = logo2[i].className.replace("active", "hidden"); 
-  logo3[i].className = logo3[i].className.replace("active", "hidden");
-  logo4[i].className = logo4[i].className.replace("active", "hidden");
-  logo5[i].className = logo5[i].className.replace("active", "hidden");
-  }
+  console.log("init", currentIndex);
+  logoIdList.forEach((logoId, index) => {
+    carousel[logoId] = document.getElementsByClassName(logoId);
+    console.log(logoId, index, carousel[logoId])
 
-  logosIndex++;
-  if (logosIndex > logo1.length) {
-	  logosIndex = 1
-	}    
-	logo1[logosIndex-1].className = logo1[logosIndex-1].className.replace("hidden", "active");  
-	logo2[logosIndex-1].className = logo2[logosIndex-1].className.replace("hidden", "active");
-	logo3[logosIndex-1].className = logo3[logosIndex-1].className.replace("hidden", "active"); 
-	logo4[logosIndex-1].className = logo4[logosIndex-1].className.replace("hidden", "active"); 
-	logo5[logosIndex-1].className = logo5[logosIndex-1].className.replace("hidden", "active"); 
+    // first hide all the logos
+    for (i = 0; i < carousel[logoId].length; i++) {
+      if (carousel[logoId][i]) {
+        carousel[logoId][i].className = carousel[logoId][i].className.replace("active", "hidden");
+      }
+    }
+    // then show only the logos from the currentIndex
+    if (carousel[logoId][currentIndex]) {
+      carousel[logoId][currentIndex].className = carousel[logoId][currentIndex].className.replace("hidden", "active");
+    }
+  });
 
+  // increment currentIndex or go back to 0
+  console.log("increment ?", currentIndex, carousel[logoIdList[0]].length)
+  currentIndex = (currentIndex === carousel[logoIdList[0]].length - 1) ? 0 : currentIndex + 1;
+
+  // run every 4 seconds
   setTimeout(showLogos, 4000);
 }

--- a/src/templates/home/home.html
+++ b/src/templates/home/home.html
@@ -98,20 +98,20 @@
 </div>
 </section>
 
-{% if random_backers %}
+{% if subset_selected_backers %}
 <section id="partner">
     <div class="container-lg">
         <h1>Les porteurs d'aides</h1>
         <div id="logos">
-            {% for random_backer in random_backers %}
+            {% for selected_backer in subset_selected_backers %}
                 <div class="{% cycle 'logo1' 'logo2' 'logo3' 'logo4' 'logo5' %} active">
-                    {% if random_backer.external_link %}
-                    <a href="{{ random_backer.external_link }}" target="_blank">
+                    {% if selected_backer.external_link %}
+                    <a href="{{ selected_backer.external_link }}" target="_blank">
                     {% else %}
-                    <a href="{{ random_backer.get_absolute_url }}">
+                    <a href="{{ selected_backer.get_absolute_url }}">
                     {% endif %}
-                        {% if random_backer.logo %}
-                        <img src="{{ random_backer.logo.url }}" alt="Logo : {{ random_backer.name }} ">
+                        {% if selected_backer.logo %}
+                        <img src="{{ selected_backer.logo.url }}" alt="Logo : {{ selected_backer.name }} ">
                         {% endif %}
                     </a>
                 </div>


### PR DESCRIPTION
https://trello.com/c/hEhKZK5r/875-pouvoir-filter-les-porteurs-par-logo

Dans la continuité de https://github.com/MTES-MCT/aides-territoires/pull/338, j'ai voulu tester les pages porteurs en local, mais je n'avais pas de logo, et du coup j'ai vu pas mal de bugs / améliorations. Les voici 😅 👇 
- Afficher dans l'admin si le porteur a un logo ou pas
- Pouvoir filtrer dans l'admin les porteurs avec logo
- Ajout de 2 QuerySet dans le modèle Backers pour pouvoir plus facilement filtrer les porteurs avec logo
- Fix de l'affichage dans la home page : les porteurs qui etaient spotlighté mais sans logo étaient quand même affichés dans le carousel
- Refactoring du carousel.js

Pourquoi avoir remplacer le filtre `logo__isnull=False` par `Q(logo='') | Q(logo=None)` ?
- Les porteurs ont par défaut `logo = None`
- Mais quand on les met à jour (par exemple juste cocher is_spotlighted, mais sans toucher au logo), le champ logo passe à `logo = ''`
- Donc j'avais dans mon carousel des porteurs qui etaient spotlightés mais qui n'avaient pourtant pas de logo
- Du coup normalement dans le home.html on pourrait enlever la condition `{% if selected_backer.logo %}` mais on sait jamais ^^