### PR TITLE
Sur Scalingo, le site ne s’affiche pas en français V2

### DIFF
--- a/src/Procfile
+++ b/src/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn core.wsgi_scalingo --log-file -
+web: bash scripts/start.sh
 postdeploy: bash scripts/postdeploy.sh

--- a/src/scripts/start.sh
+++ b/src/scripts/start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "Entering deployment start script"
+python manage.py compilemessages
+gunicorn core.wsgi_scalingo --log-file -
+echo "Completed deployment start script"


### PR DESCRIPTION
Un nouvelle proposition pour mettre le site en français : faire tourner la commande `compilemessages` systématiquement avant de lancer gunicorn.

J'ai vérifié que ça fonctionne aussi quand on redémarre le centenaire scalingo - parce que le script de démarrage qui contient les commandes `compilemessages + gunicorn` est lancé à chaque fois.