### PR TITLE
Ajout des thématiques et programmes associés sur les pages Porteur. 

### DIFF
--- a/src/backers/views.py
+++ b/src/backers/views.py
@@ -1,8 +1,41 @@
 from django.views.generic import DetailView
-from backers.models import Backer
+from django.db.models import Prefetch
 
+from backers.models import Backer
+from aids.models import Aid
+from categories.models import Category
 
 class BackerDetailView(DetailView):
     context_object_name = 'backer'
     template_name = 'backers/detail.html'
     queryset = Backer.objects.all()
+
+    def get_context_data(self, **kwargs):
+
+        categories_list = Category.objects \
+            .select_related('theme') \
+
+        aids = Aid.objects.open().published() \
+            .filter(financers=self.object.id) \
+            .prefetch_related(Prefetch('categories', queryset=categories_list))
+
+        list_themes = {}
+        for aid in aids:
+            for category in aid.categories.all():
+                list_themes[category] = category.theme
+        themes = set(list_themes.values())
+
+        categories_by_theme = {}
+        for theme in themes:
+            categories_by_theme[theme] = [k for k in list_themes.keys() if list_themes[k] == theme]
+
+        programs = Aid.objects.open().published() \
+            .filter(financers=self.object.id) \
+            .filter(programs=True)
+
+        context = super().get_context_data(**kwargs)
+        context['aids'] = aids
+        context['categories_by_theme'] = categories_by_theme
+        context['programs'] = programs
+
+        return context

--- a/src/core/settings/scalingo.py
+++ b/src/core/settings/scalingo.py
@@ -53,6 +53,10 @@ STATICFILES_DIRS = [
     Path(DJANGO_ROOT, 'node_modules'),
 ]
 
+MEDIA_URL = ''
+
+MEDIA_ROOT = ''
+
 TEMPLATES = TEMPLATES.copy()
 TEMPLATES[0]['DIRS'] = [Path(DJANGO_ROOT, 'templates')]
 

--- a/src/core/settings/scalingo.py
+++ b/src/core/settings/scalingo.py
@@ -53,9 +53,9 @@ STATICFILES_DIRS = [
     Path(DJANGO_ROOT, 'node_modules'),
 ]
 
-MEDIA_URL = ''
+MEDIA_URL = env('MEDIA_URL', default='')
 
-MEDIA_ROOT = ''
+MEDIA_ROOT = env('MEDIA_ROOT', default='')
 
 TEMPLATES = TEMPLATES.copy()
 TEMPLATES[0]['DIRS'] = [Path(DJANGO_ROOT, 'templates')]

--- a/src/core/urls.py
+++ b/src/core/urls.py
@@ -88,5 +88,6 @@ if settings.DEBUG and 'debug_toolbar' in settings.INSTALLED_APPS:
         path(r'__debug__/', include(debug_toolbar.urls)),
     ] + urlpatterns
 
+if settings.DEBUG:
     urlpatterns = static(
         settings.MEDIA_URL, document_root=settings.MEDIA_ROOT) + urlpatterns

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -2260,6 +2260,12 @@ msgstr "Dernière mise à jour"
 msgid "Global presentation"
 msgstr "Présentation générale"
 
+msgid "Related themes"
+msgstr "Thématiques associées"
+
+msgid "Related programs"
+msgstr "Programmes associés"
+
 msgid "No detailed description was submitted."
 msgstr "Aucune description détaillée n'a été renseignée."
 

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -1348,6 +1348,44 @@ div#search-steps {
     }
 }
 
+.backer-content {
+    @extend .px-5;
+
+    h2 {
+        background-color: $pale-background;
+        border-radius: 0 2rem 2rem 2rem;
+        padding: .5rem 1rem;
+        @extend .mt-4;
+    }
+
+    #program-logo img {
+    max-height: 120px;
+    }
+}
+
+ul.backer-categories {
+    padding: 0;
+    list-style-type: none;
+
+    li.theme {
+        text-transform: uppercase;
+        @extend .py-2;
+    }
+
+    ul {
+        padding: 0;
+        text-transform: none;
+
+        li {
+            display: inline;
+        }
+
+        li + li:before {
+            content: " + ";
+        }
+    } 
+}
+
 ul.aid-categories {
     padding: 0;
     list-style-type: none;

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -882,7 +882,7 @@ article#aid {
         }
         
         & > a > img {
-            max-height: 100px;
+            max-height: $height-img-base;
             max-width: 300px;
             padding: 0.5rem;
             filter: saturate(140%);
@@ -1359,7 +1359,7 @@ div#search-steps {
     }
 
     #program-logo img {
-    max-height: 120px;
+        max-height: $height-img-base;
     }
 }
 

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -1350,16 +1350,20 @@ div#search-steps {
 
 .backer-content {
     @extend .px-5;
+    @extend .mb-5;
+    @extend .mt-4;
+    line-height: 1.6;
 
     h2 {
         background-color: $pale-background;
         border-radius: 0 2rem 2rem 2rem;
         padding: .5rem 1rem;
-        @extend .mt-4;
+        @extend .my-4;
     }
 
     #program-logo img {
         max-height: $height-img-base;
+        @extend .pr-4;
     }
 }
 

--- a/src/static/css/_theme.scss
+++ b/src/static/css/_theme.scss
@@ -75,3 +75,5 @@ $box-shadow:                  0 .5rem 1rem rgba($dark, .9);
 $box-shadow-lg:               0 1rem 3rem rgba($dark, .9);
 
 $print-page-size: a4;
+
+$height-img-base: 100px;

--- a/src/templates/backers/detail.html
+++ b/src/templates/backers/detail.html
@@ -13,10 +13,65 @@
 {% endblock %}
 
 {% block content %}
-<article>
-<h1>{{ backer.name }}</h1>
+<article id="backer">
 
-{{ backer.description|safe }}
+    <section class="backer-content">
+
+        <h1>{{ backer.name }}</h1>
+
+        {% if backer.description %}
+            <div>
+                <h2>Présentation générale :</h2>
+                {{ backer.description|safe }}
+            </div>
+        {% endif %}   
+
+        {% if aids %}
+        <div>
+            <h2>Thématiques associées :</h2>
+            <ul class="backer-categories">
+            {% for key,values in categories_by_theme.items %}
+                <li class="theme">
+                    <strong>
+                        {{ key }}
+                    </strong>
+                    <ul>
+                        {% for value in values %}
+                        <li class="category">{{ value }}</li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endfor %}
+            </ul>
+        </div>
+        {% endif %}
+        
+        {% if programs %}
+        <div>
+            <h2>Programmes associés :</h2>
+            <div id="program-logo">
+            {% for aid in aids %}
+            {% if aid.programs %}
+                {% for program in aid.programs.all %}
+                {% if program.logo %}
+                    <a href="{% url 'program_detail' program.slug %}">
+                        <img src="{{ program.logo.url }}" alt="{{ program.name }}">
+                    </a>
+                {% else %}
+                <p class="program">
+                    <strong>
+                        {{ program }}
+                    </strong>
+                </p>
+                {% endif %}
+                {% endfor %}
+            {% endif %}
+            {% endfor %}
+            </div>
+        </div>
+        {% endif %}
+            
+    </section>
 
 </article>
 {% endblock %}

--- a/src/templates/backers/detail.html
+++ b/src/templates/backers/detail.html
@@ -29,21 +29,21 @@
         {% if aids %}
         <div>
             <h2>{{ _('Related themes') }}</h2>
-            <ul class="backer-categories">
-            {% for key,values in categories_by_theme.items %}
-                <li class="theme">
-                    <strong>
-                        {{ key }}
-                    </strong>
-                    <ul>
-                        {% for value in values %}
-                        <li class="category">{{ value }}</li>
+            {% regroup categories by theme as theme_list %}
+            <ul class="aid-categories">
+                {% for theme in theme_list %}
+                    <li class="theme">
+                        <strong>
+                        {{ theme.grouper }}
+                        </strong>
+                        <ul>
+                        {% for category in theme.list %}
+                            <li class="category">{{ category.name }}</li>
                         {% endfor %}
-                    </ul>
-                </li>
-            {% endfor %}
+                        </ul>
+                    </li>
+                {% endfor %}
             </ul>
-        </div>
         {% endif %}
         
         {% if programs %}

--- a/src/templates/backers/detail.html
+++ b/src/templates/backers/detail.html
@@ -21,14 +21,14 @@
 
         {% if backer.description %}
             <div>
-                <h2>Présentation générale :</h2>
+                <h2>{{ _('Global presentation') }}</h2>
                 {{ backer.description|safe }}
             </div>
         {% endif %}   
 
         {% if aids %}
         <div>
-            <h2>Thématiques associées :</h2>
+            <h2>{{ _('Related themes') }}</h2>
             <ul class="backer-categories">
             {% for key,values in categories_by_theme.items %}
                 <li class="theme">
@@ -48,24 +48,12 @@
         
         {% if programs %}
         <div>
-            <h2>Programmes associés :</h2>
+            <h2>{{ _('Related programs') }}</h2>
             <div id="program-logo">
-            {% for aid in aids %}
-            {% if aid.programs %}
-                {% for program in aid.programs.all %}
-                {% if program.logo %}
-                    <a href="{% url 'program_detail' program.slug %}">
-                        <img src="{{ program.logo.url }}" alt="{{ program.name }}">
-                    </a>
-                {% else %}
-                <p class="program">
-                    <strong>
-                        {{ program }}
-                    </strong>
-                </p>
-                {% endif %}
-                {% endfor %}
-            {% endif %}
+            {% for program in programs %}
+                <a href="{% url 'program_detail' program.slug %}">
+                    <img src="{{ program.logo.url }}" alt="{{ program.name }}">
+                </a>
             {% endfor %}
             </div>
         </div>

--- a/src/templates/backers/detail.html
+++ b/src/templates/backers/detail.html
@@ -30,7 +30,7 @@
         <div>
             <h2>{{ _('Related themes') }}</h2>
             {% regroup categories by theme as theme_list %}
-            <ul class="aid-categories">
+            <ul class="backer-categories">
                 {% for theme in theme_list %}
                     <li class="theme">
                         <strong>


### PR DESCRIPTION
Première partie de la carte https://trello.com/c/lbNwvDST/843-fiche-porteur-en-admin-sur-at-affichage-des-th%C3%A9matiques-des-aides.

Permet l'affichage sur chaque page porteur, des thématiques, catégories et programmes associés aux aides de ce porteur.

- Dans le fichier `backers/views.py`, ajout d'une `def get_context` pour récupérer les thématiques, catégories et programmes associés aux aides du porteur.
- Dans le fichier `templates/backers/detail.html`, ajout d'une section pour l'affichage des thématiques, catégories et programmes.
- Ajout du style dans le fichier `_custom.scss`