### PR TITLE
Ajout d'un séparateur '|' entre les types d'aides sur les cartes des aides. 

### DIFF
--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -511,6 +511,16 @@ section#program-list {
                 padding: 0;
                 list-style: none;
             }
+
+            #aid-type-list {
+                li {
+                    display: inline;
+                }
+        
+                li + li::before {
+                    content: " | ";
+                }
+            }
         }
     }
 

--- a/src/templates/aids/_aid_result.html
+++ b/src/templates/aids/_aid_result.html
@@ -33,14 +33,18 @@
 
         {% if aid.is_financial or aid.is_technical %}
             <h2 class="aid-type">{{ _('Aid type') }}</h2>
-            <p>
+            <ul id="aid-type-list">
                 {% if aid.is_financial %}
+                <li>
                     {{ _('Financial aid') }}
+                </li>   
                 {% endif %}
                 {% if aid.is_technical %}
+                <li>
                     {{ _('Engineering aid') }}
+                </li>
                 {% endif %}
-            </p>
+            </ul>
         {% endif %}
 
         {% if aid.subvention_rate %}


### PR DESCRIPTION
https://trello.com/c/h3rhLMfm/860-affichage-r%C3%A9sultats-ajout-s%C3%A9parateur