### PR TITLE
  Modification du champ AAP/AMI dans le cartouche "plus de critères" 

### DIFF
--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -626,7 +626,7 @@ msgid "Recurrence"
 msgstr "Récurrence"
 
 msgid "Call for projects only"
-msgstr "AAP / AMI uniquement"
+msgstr "Appels à projets / Appels à manifestation d’intérêt uniquement"
 
 msgid "Aid programs"
 msgstr "Programmes d'aides"

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -306,11 +306,15 @@ section#search-engine {
 
         div.form-check-inline {
             align-items: baseline;
-            margin-bottom: 1rem;
             font-weight: bold;
 
             input[type=checkbox] {
                 margin-right: 0.5rem;
+                margin-bottom: 2rem;
+            }
+
+            label {
+                margin: 0;
             }
         }
 

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -315,6 +315,7 @@ section#search-engine {
 
             label {
                 margin: 0;
+                line-height: 1.7rem;
             }
         }
 

--- a/src/templates/aids/_search_form.html
+++ b/src/templates/aids/_search_form.html
@@ -61,7 +61,7 @@
                     </div> 
                     {% endfor %}
 
-                <div class="form-group checkbox-group">
+                <div class="form-check form-check-inline">
                     {{ form.call_for_projects_only }}
                     <label>
                         {{ form.call_for_projects_only.label }}


### PR DESCRIPTION
**(Recréation de la PR #331 pour déploiement de la reviewApp sur Scalingo).**

https://trello.com/c/CRzbM0ZQ/732-changement-de-texte-cartouche-plus-de-crit%C3%A8res

Dans le formulaire "plus de critères" on remplace le champ AAP / AMI uniquement par Appels à projets / Appels à manifestation d’intérêt uniquement