### PR TITLE
Envoi d'emails via l'API de Sendinblue

### DIFF
--- a/src/accounts/management/commands/export_contacts.py
+++ b/src/accounts/management/commands/export_contacts.py
@@ -1,5 +1,6 @@
 import requests
 import json
+
 from django.core.management.base import BaseCommand
 from django.conf import settings
 

--- a/src/accounts/tasks.py
+++ b/src/accounts/tasks.py
@@ -6,7 +6,7 @@ from django.utils.encoding import force_bytes
 from django.urls import reverse
 
 from core.celery import app
-from core.mail_backends import send_mail_with_sendinblue_transactional_api
+from core.mail_backends import send_mail_sib
 from accounts.models import User
 
 
@@ -48,7 +48,7 @@ def send_connection_email(user_email, body_template='emails/login_token.txt'):
         'user_name': user.full_name,
         'full_login_url': full_login_url})
 
-    send_mail_with_sendinblue_transactional_api(
+    send_mail_sib(
         LOGIN_SUBJECT,
         login_email_body,
         user.email,

--- a/src/accounts/tasks.py
+++ b/src/accounts/tasks.py
@@ -1,11 +1,9 @@
-from django.core.mail import send_mail
 from django.contrib.sites.models import Site
 from django.template.loader import render_to_string
 from django.contrib.auth.tokens import default_token_generator
 from django.utils.http import urlsafe_base64_encode
 from django.utils.encoding import force_bytes
 from django.urls import reverse
-from django.conf import settings
 
 from core.celery import app
 from core.mail_backends import send_mail_with_sendinblue_transactional_api
@@ -55,9 +53,3 @@ def send_connection_email(user_email, body_template='emails/login_token.txt'):
         login_email_body,
         user.email,
         tag_list=['connexion'])
-    # send_mail(
-    #     LOGIN_SUBJECT,
-    #     login_email_body,
-    #     settings.DEFAULT_FROM_EMAIL,
-    #     [user.email],
-    #     fail_silently=False)

--- a/src/accounts/tasks.py
+++ b/src/accounts/tasks.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from django.conf import settings
 
 from core.celery import app
+from core.mail_backends import send_mail_with_sendinblue_transactional_api
 from accounts.models import User
 
 
@@ -48,9 +49,15 @@ def send_connection_email(user_email, body_template='emails/login_token.txt'):
         'base_url': base_url,
         'user_name': user.full_name,
         'full_login_url': full_login_url})
-    send_mail(
+
+    send_mail_with_sendinblue_transactional_api(
         LOGIN_SUBJECT,
         login_email_body,
-        settings.DEFAULT_FROM_EMAIL,
-        [user.email],
-        fail_silently=False)
+        user.email,
+        tag_list=['connexion'])
+    # send_mail(
+    #     LOGIN_SUBJECT,
+    #     login_email_body,
+    #     settings.DEFAULT_FROM_EMAIL,
+    #     [user.email],
+    #     fail_silently=False)

--- a/src/core/mail_backends.py
+++ b/src/core/mail_backends.py
@@ -1,8 +1,56 @@
+import json
+import requests
 import smtplib
 
 from django.core.mail.backends.smtp import EmailBackend
 from django.core.mail.message import sanitize_address
 from django.conf import settings
+
+
+API_HEADERS = {
+    'accept': 'application/json',
+    'content-type': 'application/json',
+    'api-key': settings.SIB_API_KEY,
+}
+
+
+def send_mail_with_sendinblue_transactional_api(subject, email_body, to_email, from_email=settings.DEFAULT_FROM_EMAIL, email_body_type='text', tag_list=None):  # noqa
+    """
+    Method to send emails using the Sendinblue API
+
+    Why the API and not the SMTP Relay ?
+    - You can add tags to the emails you send
+    - You can pass the link to an email template created in Sendinblue
+
+    More info here:
+    https://developers.sendinblue.com/docs/send-a-transactional-email
+    """
+    endpoint = settings.SIB_TRANSACTIONAL_API_ENDPOINT
+    data = {
+        'sender': {
+            'email': from_email,
+            # 'name': 'Aides-territoires'
+        },
+        'to': [{
+            'email': to_email,
+            # 'name': 'John Doe'
+        }],
+        'subject': subject,
+        # 'htmlContent': email_body,
+        # 'textContent': email_body,
+        # 'htmlUrl': sendinblue_template_url
+        # 'tags': ['']
+    }
+    # set email_body
+    if email_body_type == 'html':
+        data['htmlContent'] = email_body
+    else:
+        data['textContent'] = email_body
+    # set sendinblue tags
+    if tag_list:
+        data['tags'] = tag_list
+
+    requests.post(endpoint, headers=API_HEADERS, data=json.dumps(data))
 
 
 class StagingEmailBackend(EmailBackend):

--- a/src/core/mail_backends.py
+++ b/src/core/mail_backends.py
@@ -14,43 +14,23 @@ API_HEADERS = {
 }
 
 
-def send_mail_with_sendinblue_transactional_api(subject, email_body, to_email, from_email=settings.DEFAULT_FROM_EMAIL, email_body_type='text', tag_list=None):  # noqa
+def send_mail_sib(subject, email_body, to_email, from_email=settings.DEFAULT_FROM_EMAIL, email_body_type='text', tag_list=None):  # noqa
     """
-    Method to send emails using the Sendinblue API
-
-    Why the API and not the SMTP Relay ?
-    - You can add tags to the emails you send
-    - You can pass the link to an email template created in Sendinblue
-
-    More info here:
-    https://developers.sendinblue.com/docs/send-a-transactional-email
+    Sends emails using the Sendinblue Transactional API.
     """
     endpoint = settings.SIB_TRANSACTIONAL_API_ENDPOINT
-    data = {
-        'sender': {
-            'email': from_email,
-            # 'name': 'Aides-territoires'
-        },
-        'to': [{
-            'email': to_email,
-            # 'name': 'John Doe'
-        }],
+    post_data = {
+        'sender': {'email': from_email},
+        'to': [{'email': to_email}],
         'subject': subject,
-        # 'htmlContent': email_body,
-        # 'textContent': email_body,
-        # 'htmlUrl': sendinblue_template_url
-        # 'tags': ['']
     }
-    # set email_body
     if email_body_type == 'html':
-        data['htmlContent'] = email_body
+        post_data['htmlContent'] = email_body
     else:
-        data['textContent'] = email_body
-    # set sendinblue tags
+        post_data['textContent'] = email_body
     if tag_list:
-        data['tags'] = tag_list
-
-    requests.post(endpoint, headers=API_HEADERS, data=json.dumps(data))
+        post_data['tags'] = tag_list
+    requests.post(endpoint, headers=API_HEADERS, data=json.dumps(post_data))
 
 
 class StagingEmailBackend(EmailBackend):

--- a/src/core/settings/base.py
+++ b/src/core/settings/base.py
@@ -252,3 +252,4 @@ SEARCH_COOKIE_NAME = 'currentsearch'
 
 SIB_API_KEY = ''
 SIB_LIST_ID = ''
+SIB_TRANSACTIONAL_API_ENDPOINT = 'https://api.sendinblue.com/v3/smtp/email'


### PR DESCRIPTION
Experimentation pour envoyer les emails grâce à l'API de Sendinblue (et non leur SMTP Relay)

Why the API and not the SMTP Relay ?
- You can add tags to the emails you send
- You can pass the link to an email template created in Sendinblue
- But you have a bit more configuration than the default django `send_mail()`