### PR TITLE
Modifie le message lors de la duplication d'une aide 

### DIFF
--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -416,7 +416,7 @@ class AidEditView(ContributorRequiredMixin, MessageMixin, AidEditMixin,
             form.save_m2m()
             msg = _('The new aid was sucessfully created. You can keep editing it. '
                     'And find the duplicated aid in <a href="%(url)s">your portfolio</a>.') % {
-                        'url': aid_draft_list_view
+                        'url': reverse('aid_draft_list_view')
                     }
 
             response = HttpResponseRedirect(self.get_success_url())

--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -414,8 +414,10 @@ class AidEditView(ContributorRequiredMixin, MessageMixin, AidEditMixin,
             obj.import_uniqueid = None
             obj.save()
             form.save_m2m()
-            msg = _('The new aid was sucessfully created. You can keep '
-                    'editing it.')
+            msg = _('The new aid was sucessfully created. You can keep editing it. '
+                    'And find the duplicated aid in <a href="%(url)s">your portfolio</a>.') % {
+                        'url': aid_draft_list_view
+                    }
 
             response = HttpResponseRedirect(self.get_success_url())
         else:

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -943,8 +943,13 @@ msgstr ""
 "Votre aide a été créée. Vous pouvez poursuivre l'édition ou <a href=\"%(url)s"
 "\" target=\"_blank\">la prévisualiser</a>."
 
-msgid "The new aid was sucessfully created. You can keep editing it."
-msgstr "La nouvelle aide a été créée. Vous pouvez poursuivre l'édition."
+#, python-format
+msgid ""
+"The new aid was sucessfully created. You can keep editing it. "
+"And find the duplicated aid in <a href=\"%(url)s"\>your portfolio</a>."
+msgstr ""
+"La nouvelle aide a été créée. Vous pouvez poursuivre l'édition. "
+"Et retrouvez l'aide dupliquée sur <a href=\"%(url)s\">votre portefeuille d'aides</a>."
 
 msgid "The aid was sucessfully updated. You can keep editing it."
 msgstr "L'aide a bien été mise à jour. Vous pouvez poursuivre l'édition."

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -946,7 +946,7 @@ msgstr ""
 #, python-format
 msgid ""
 "The new aid was sucessfully created. You can keep editing it. "
-"And find the duplicated aid in <a href=\"%(url)s"\>your portfolio</a>."
+"And find the duplicated aid in <a href=\"%(url)s\">your portfolio</a>."
 msgstr ""
 "La nouvelle aide a été créée. Vous pouvez poursuivre l'édition. "
 "Et retrouvez l'aide dupliquée sur <a href=\"%(url)s\">votre portefeuille d'aides</a>."


### PR DESCRIPTION
https://trello.com/c/DPbXG4lf/859-modifie-le-message-lors-de-la-duplication-dune-aide

Modification du message affiché lors de la duplication d'une aide. 