### PR TITLE
Conditionne l'affichage du titre "échéance" sur les cartes de résultats des aides

### DIFF
--- a/src/templates/aids/_aid_result.html
+++ b/src/templates/aids/_aid_result.html
@@ -72,7 +72,7 @@
                 <li>{{ _('Opening:') }} {{ aid.start_date|date }}</li>
             {% endif %}
             {% if aid.submission_deadline %}
-            <li>{{ _('Deadline:') }} {{ aid.submission_deadline|date }}</li>
+                <li>{{ _('Deadline:') }} {{ aid.submission_deadline|date }}</li>
             {% endif %}
             </ul>
         {% endif %}

--- a/src/templates/aids/_aid_result.html
+++ b/src/templates/aids/_aid_result.html
@@ -71,7 +71,9 @@
             {% if aid.start_date %}
                 <li>{{ _('Opening:') }} {{ aid.start_date|date }}</li>
             {% endif %}
+            {% if aid.submission_deadline %}
             <li>{{ _('Deadline:') }} {{ aid.submission_deadline|date }}</li>
+            {% endif %}
             </ul>
         {% endif %}
 


### PR DESCRIPTION
https://trello.com/c/QoKJ82cM/885-conditionne-laffichage-du-titre-%C3%A9ch%C3%A9ance-sur-les-cartes-de-r%C3%A9sultats-des-aides

Conditionne l'affichage du titre 'échéance' à l'existence d'une date d'échéance sur les cartes de résultats des aides. 