### PR TITLE
 Améliore l'outil de détection de doublons en admin

### DIFF
--- a/src/aids/tests/test_api.py
+++ b/src/aids/tests/test_api.py
@@ -51,3 +51,33 @@ def test_api_invalid_version(client, api_url):
 
     res = client.get('f{api_url}?version=42')
     assert res.status_code == 404
+
+
+def test_superuser_can_search_among_aid_drafts(superuser_client, api_url):
+    AidFactory(name='First aid')
+    AidFactory(name='Draft aid', status='draft')
+
+    res = superuser_client.get(f'{api_url}?version=1.1')
+    assert res.status_code == 200
+    content = json.loads(res.content.decode())
+    assert content['count'] == 1
+
+    res = superuser_client.get(f'{api_url}?version=1.1&drafts=True')
+    assert res.status_code == 200
+    content = json.loads(res.content.decode())
+    assert content['count'] == 2
+
+
+def test_users_cannot_search_among_aid_drafts(user_client, api_url):
+    AidFactory(name='First aid')
+    AidFactory(name='Draft aid', status='draft')
+
+    res = user_client.get(f'{api_url}?version=1.1')
+    assert res.status_code == 200
+    content = json.loads(res.content.decode())
+    assert content['count'] == 1
+
+    res = user_client.get(f'{api_url}?version=1.1&drafts=True')
+    assert res.status_code == 200
+    content = json.loads(res.content.decode())
+    assert content['count'] == 1

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -44,6 +44,12 @@ def superuser():
 
 
 @pytest.fixture
+def superuser_client(superuser, client):
+    client.force_login(superuser)
+    return client
+
+
+@pytest.fixture
 def backer():
     """Generates a valid Backer."""
 

--- a/src/static/js/aids/duplicate_buster.js
+++ b/src/static/js/aids/duplicate_buster.js
@@ -6,11 +6,13 @@
     const API_ENDPOINT = '/api/aids/?version=1.1&drafts=True';
 
     // Create a div to hold the error message
-    var errorDiv = $('<div class="inline-error"></div>');
+    var topErrorDiv = $('<div class="inline-error"></div>');
+    var inlineErrorDiv = $('<div class="inline-error"></div>');
 
     // Insert the message holding div into the dom
     var initializeErrorDom = function() {
-        errorDiv.insertAfter('input#id_origin_url');
+        topErrorDiv.insertAfter('textarea#id_name');
+        inlineErrorDiv.insertAfter('input#id_origin_url');
     };
 
     // Generate a link to a single duplicate aid
@@ -91,10 +93,12 @@
 
         // Be careful as to not count the current aid as a duplicate of itself
         if (count == 0 || count == 1 && results[0]['slug'] == currentSlug) {
-            errorDiv.html('');
+            topErrorDiv.html('');
+            inlineErrorDiv.html('');
         } else {
             var msg = displayWarningMessage(duplicates);
-            errorDiv.html(msg);
+            topErrorDiv.html(msg);
+            inlineErrorDiv.html(msg.clone());
         }
     };
 

--- a/src/static/js/aids/duplicate_buster.js
+++ b/src/static/js/aids/duplicate_buster.js
@@ -115,5 +115,7 @@
         initializeErrorDom();
         aidEditForm.on('change', warnForDuplicates);
 
+        // Check duplicate when the form is first displayed
+        warnForDuplicates();
     });
 }($ || django.jQuery));

--- a/src/static/js/aids/duplicate_buster.js
+++ b/src/static/js/aids/duplicate_buster.js
@@ -5,9 +5,6 @@
 
     const API_ENDPOINT = '/api/aids/?version=1.1&drafts=True';
 
-    var form = $('form#aid_form');
-    var urlField = $('#id_origin_url');
-
     // Create a div to hold the error message
     var errorDiv = $('<div class="inline-error"></div>');
 

--- a/src/static/js/aids/duplicate_buster.js
+++ b/src/static/js/aids/duplicate_buster.js
@@ -33,12 +33,15 @@
      */
     var displayWarningMessage = function(apiData) {
         var messageDiv = $('<div class="errornote" />');
-
         var messageP = $('<p>Attention ! Nous avons trouvé des aides qui ressemblent à des doublons.</p>');
 
+        var currentSlug = $('#id_slug').val();
         var count = apiData['count'];
         var maxResults = Math.min(count, MAX_RESULTS);
         var duplicates = apiData['results']
+            .filter(function(result) {
+                return result['slug'] != currentSlug;
+            })
             .slice(0, maxResults)
             .map(formatSingleDuplicate);
 

--- a/src/static/js/aids/duplicate_buster.js
+++ b/src/static/js/aids/duplicate_buster.js
@@ -3,7 +3,7 @@
 
     const MAX_RESULTS = 5;  // Don't display more duplicate
 
-    const API_ENDPOINT = '/api/aids/?version=1.1';
+    const API_ENDPOINT = '/api/aids/?version=1.1&drafts=True';
 
     var form = $('form#aid_form');
     var urlField = $('#id_origin_url');


### PR DESCRIPTION
- Recherche les doublons parmi les aides non publiées
- Lance la recherche dés l'affichage du formulaire d'admin
- Copie le message d'erreur en haut du formulaire pour le rendre plus visible
- N'affiche plus l'aide actuelle dans la liste des doublons
