### PR TITLE
Préfixe le nom des aides dupliquées

### DIFF
--- a/src/aids/tests/test_views.py
+++ b/src/aids/tests/test_views.py
@@ -178,7 +178,8 @@ def test_aid_edition_save_as_new(client, contributor, amendment_form_data):
     assert aids.count() == 2
 
     assert aids[0].name == 'First title'
-    assert aids[1].name == 'Second title'
+    assert '[Copie' in aids[1].name
+    assert 'Second title' in aids[1].name
 
     assert aids[0].status == 'published'
     assert aids[1].status == 'draft'

--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -25,6 +25,7 @@ from aids.forms import (AidEditForm, AidAmendForm, AidSearchForm,
                         AdvancedAidFilterForm, DraftListAidFilterForm)
 from aids.models import Aid, AidWorkflow
 from aids.tasks import log_admins
+from aids.utils import generate_clone_title
 from alerts.forms import AlertForm
 from categories.models import Category
 from minisites.mixins import SearchMixin, AidEditMixin, NarrowedFiltersMixin
@@ -413,6 +414,7 @@ class AidEditView(ContributorRequiredMixin, MessageMixin, AidEditMixin,
             obj.status = AidWorkflow.states.draft
             obj.is_imported = False
             obj.import_uniqueid = None
+            obj.name = generate_clone_title(obj.name)
             obj.save()
             form.save_m2m()
             msg = _('The new aid was sucessfully created. '


### PR DESCRIPTION
Ajoute « [Copie] » devant le nom des aides dupliquées en frontend.