### PR TITLE
Ajout du filtre programme dans le cartouche de recherche

### DIFF
--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -1638,7 +1638,7 @@ msgid "Type a few characters to see some suggestions."
 msgstr "Saisissez quelques caractères pour des suggestions."
 
 msgid "Choose backer(s) among the list."
-msgstr "Sélectionnez le·s porteur·s parmi la liste."
+msgstr "Sélectionnez le·s porteur·s"
 
 msgid "Choose instructor(s) among the list."
 msgstr "Sélectionnez le·s instructeur·s parmi la liste."

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -333,7 +333,8 @@ section#search-engine {
         }
 
         #form-group-text label,
-        #form-group-backers label {
+        #form-group-backers label,
+        #form-group-programs label {
             margin-bottom: 1rem;
         }
 

--- a/src/templates/aids/_base_search.html
+++ b/src/templates/aids/_base_search.html
@@ -82,6 +82,7 @@
 <script src="/static/select2/dist/js/select2.js"></script>
 <script src="/static/select2/dist/js/i18n/fr.js"></script>
 <script src="/static/js/aids/backers_autocomplete.js"></script>
+<script src="/static/js/aids/programs_autocomplete.js"></script>
 <script src="/static/js/alerts/alert_form.js"></script>
 <script src="/static/js/aids/bookmark_results.js"></script>
 {% endcompress %}

--- a/src/templates/aids/_search_form.html
+++ b/src/templates/aids/_search_form.html
@@ -54,26 +54,19 @@
 
         {% block form-body %}
         <div class="row">
-            <div class="col col-md-4">
-                    {% for choice in form.aid_type %}
-                    <div class="form-check form-check-inline">
-                        {{ choice }}
-                    </div> 
-                    {% endfor %}
-
-                <div class="form-check form-check-inline">
-                    {{ form.call_for_projects_only }}
-                    <label>
-                        {{ form.call_for_projects_only.label }}
-                    </label>
-                </div>
+            <div class="col col-md-3">
+                {% include '_field_snippet.html' with field=form.aid_type %}
             </div>
 
-            <div class="col col-md-4">
+            <div class="col col-md-3">
+                {% include '_field_snippet.html' with field=form.programs %}
+            </div>
+
+            <div class="col col-md-3">
                 {% include '_field_snippet.html' with field=form.backers %}
             </div>
 
-            <div class="col col-md-4">
+            <div class="col col-md-3">
                 {% include '_field_snippet.html' with field=form.text %}
             </div>
         </div>
@@ -81,10 +74,10 @@
 
         {% block form-actions %}
         <div class="row actions-row">
-            <div class="col-md-4 offset-md-4">
+            <div class="col-md-3">
                 {{ form.order_by }}
             </div>
-            <div class="col-md-4">
+            <div class="col-md-3 offset-md-6">
                 <button name="action" value="search" class="search-btn" type="submit">
                     {{ _('Filter results') }}
                 </button>


### PR DESCRIPTION
https://trello.com/c/YVXRXlxe/897-ajout-du-filtre-programme-dans-le-cartouche-de-recherche

Ajout du filtre programme dans le cartouche de recherche. 
Suppression du filtre AAP/AMI.
Redesign du cartouche de recherche en 4 colonnes.