### PR TITLE
Affichage responsive des logos sur les fiches aides et ajout du lien vers page porteur

### DIFF
--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -898,7 +898,7 @@ article#aid {
         
         & > a > img {
             max-height: $height-img-base;
-            max-width: 300px;
+            max-width: 225px;
             padding: 0.5rem;
             filter: saturate(140%);
         }

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -890,6 +890,7 @@ article#aid {
         flex-direction: row;
         flex-wrap: wrap;
         justify-content: space-around;
+        align-items: center;
         border: none;
 
         & > a[href^="http"]::after {

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -204,7 +204,7 @@
 
                 {% for financer in financers %}
                 {% if financer.logo %}
-                <a href="#">
+                <a href="{% url 'backer_detail_view' financer.pk financer.slug %}">
                     <img src="{{ financer.logo.url }}" alt="{{ financer.name }}">
                 </a>
                 {% endif %}


### PR DESCRIPTION
https://trello.com/c/yP8DnSnD/907-affichage-responsive-des-logos-sur-les-fiches-aides-et-ajout-du-lien-vers-page-porteur

- Modification de la `max-width` des logos sur la page `AidDetail` pour uniformiser les tailles et améliorer l'affichage responsive
- Ajout sur le logo du lien vers la page `porteurDetail`. 