### PR TITLE
Recherche de périmètres sans accents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
     - name: Set up the database
       run: |
         psql -d postgresql://aides:aides@localhost/template1 -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'
+        psql -d postgresql://aides:aides@localhost/template1 -c 'CREATE EXTENSION IF NOT EXISTS unaccent;'
       env:
         PGPASSWORD: aides
 

--- a/deployment/roles/appservers/tasks/database.yml
+++ b/deployment/roles/appservers/tasks/database.yml
@@ -22,3 +22,4 @@
   with_items:
     - btree_gin
     - pg_trgm
+    - unaccent

--- a/src/geofr/api/views.py
+++ b/src/geofr/api/views.py
@@ -18,8 +18,8 @@ class PerimeterViewSet(viewsets.ReadOnlyModelViewSet):
         q = self.request.query_params.get('q', '')
         if len(q) >= MIN_SEARCH_LENGTH:
             qs = qs \
-                .annotate(similarity=TrigramSimilarity('name', q)) \
-                .filter(name__trigram_similar=q) \
+                .annotate(similarity=TrigramSimilarity('name__unaccent', q)) \
+                .filter(name__unaccent__trigram_similar=q) \
                 .order_by('-similarity', '-scale', 'name')
 
         return qs

--- a/src/geofr/api/views.py
+++ b/src/geofr/api/views.py
@@ -1,11 +1,18 @@
+import unicodedata
 from rest_framework import viewsets
 from django.contrib.postgres.search import TrigramSimilarity
+from django.contrib.postgres.lookups import Unaccent
 
 from geofr.models import Perimeter
 from geofr.api.serializers import PerimeterSerializer
 
 
 MIN_SEARCH_LENGTH = 1
+
+
+def remove_accents(input_str):
+    nfkd_form = unicodedata.normalize('NFKD', input_str)
+    return u"".join([c for c in nfkd_form if not unicodedata.combining(c)])
 
 
 class PerimeterViewSet(viewsets.ReadOnlyModelViewSet):
@@ -18,8 +25,8 @@ class PerimeterViewSet(viewsets.ReadOnlyModelViewSet):
         q = self.request.query_params.get('q', '')
         if len(q) >= MIN_SEARCH_LENGTH:
             qs = qs \
-                .annotate(similarity=TrigramSimilarity('name__unaccent', q)) \
-                .filter(name__unaccent__trigram_similar=q) \
+                .annotate(similarity=TrigramSimilarity(Unaccent('name'), q)) \
+                .filter(name__unaccent__trigram_similar=remove_accents(q)) \
                 .order_by('-similarity', '-scale', 'name')
 
         return qs

--- a/src/scripts/first_deploy.sh
+++ b/src/scripts/first_deploy.sh
@@ -11,6 +11,7 @@ PG_EXCLUDE_SCHEMA="-N 'information_schema' -N '^pg_*'"
 pg_dump $PG_OPTIONS $PG_EXCLUDE_SCHEMA --dbname $STAGING_DATABASE_URL --format c --file /tmp/dump.pgsql
 pg_restore $PG_OPTIONS --dbname $DATABASE_URL /tmp/dump.pgsql
 psql -d $DATABASE_URL -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'
+psql -d $DATABASE_URL -c 'CREATE EXTENSION IF NOT EXISTS unaccent;'
 
 # We want to include commands from the post deploy hook as well:
 bash $HOME/scripts/post_deploy.sh


### PR DESCRIPTION
La recherche de périmètre (dans l'autocomplétion) est désormais insensible aux accents.

**NOTE IMPORTANTE** pour mes distingués collègues !

La fusion de cette PR va vraissemblablement rendre votre connexion à votre base invalide, car Postgres se plaindra qu'il manque l'extension « unaccent ».

Pour résoudre ce problème, il suffit de se connecter à la BD et d'activer l'extension.

> psql aides
> aides=# CREATE EXTENSION unaccent;