### PR TITLE
Réduit le nombre de requêtes SQL sur les pages programme

### DIFF
--- a/src/programs/views.py
+++ b/src/programs/views.py
@@ -1,6 +1,7 @@
 from django.views.generic import ListView, DetailView
 
 from programs.models import Program
+from aids.models import Aid
 
 
 class ProgramList(ListView):
@@ -15,7 +16,14 @@ class ProgramList(ListView):
 class ProgramDetail(DetailView):
     template_name = 'programs/detail.html'
     context_object_name = 'program'
+    queryset = Program.objects.all()
 
-    def get_queryset(self):
-        qs = Program.objects.all()
-        return qs
+    def get_context_data(self, **kwargs):
+
+        aids = Aid.objects.live() \
+            .filter(programs=self.object.id)
+
+        context = super().get_context_data(**kwargs)
+        context['aids'] = aids
+
+        return context

--- a/src/templates/programs/detail.html
+++ b/src/templates/programs/detail.html
@@ -25,7 +25,7 @@
 
 <section id="aid-list">
     <div class="aids">
-        {% for aid in program.aids.all %}
+        {% for aid in aids %}
         <div class="col">
             {% include 'aids/_aid_result.html' with aid=aid %}
         </div>


### PR DESCRIPTION
94 requêtes SQL étaient faites sur les pages `programDetail` pour afficher la liste des aides associées.

Reprise du code pour passer à 10 requêtes SQL. 