### PR TITLE
Bug : le filtre program restait dans l'url malgré sa suppression du formulaire.

### DIFF
--- a/src/templates/aids/_search_form.html
+++ b/src/templates/aids/_search_form.html
@@ -16,7 +16,6 @@
         {{ form.targeted_audiences.as_hidden }}
         {{ form.perimeter.as_hidden }}
         {{ form.themes.as_hidden }}
-        {{ form.programs.as_hidden }}
     {% endblock %}
 
     {% block other_actions %}


### PR DESCRIPTION
Correction d'un bug liée à la PR #372 : le filtre programme demeurait dans la query malgré sa suppression du formulaire : 

- suppression de la ligne `{{ form.programs.as_hidden }} `dans le fichier _search_form.html