### PR TITLE
Simplifie la suggestion de nouveaux apporteurs sur le formulaire d'édition

### DIFF
--- a/src/static/js/aids/toggle_aid_instructor_field.js
+++ b/src/static/js/aids/toggle_aid_instructor_field.js
@@ -31,6 +31,6 @@
 $(document).ready(function () {
 
     var aidEditForm = $('form.main-form');
-    var instructorDiv = $('#form-group-instructors');
+    var instructorDiv = $('#instructor-fields');
     toggleInstructorField(aidEditForm, instructorDiv);
 });

--- a/src/static/js/backers_autocomplete.js
+++ b/src/static/js/backers_autocomplete.js
@@ -1,50 +1,14 @@
 /**
  * Handle the code related to the financer and instructor fields.
  *  - create the autocomplete fields using select2
- *  - handle the "suggestion" fields
  */
-
-(function (exports) {
-    'use strict';
-
-    /**
-     * Hide the backer suggestion field using bootstrap's collapse mechanism
-     */
-    exports.hideSuggestionField = function (field) {
-        var field = $('form#aid-edit-form #form-group-' + field);
-        var input = field.find('input');
-
-        // Note: don't hide the field if it actually holds a value
-        if (input.val() === '') {
-            field.addClass('collapse');
-        }
-    };
-
-    /**
-     * Prepares an event listener to show and set focus to the suggestion field
-     */
-    exports.showSuggestionField = function (backerFieldName, suggestionFieldName) {
-        var select2Field = $('#id_' + backerFieldName);
-        var suggestionFieldFormGroup = $('#form-group-' + suggestionFieldName);
-        var suggestionField = $('#id_' + suggestionFieldName);
-
-        // This function will be called when the suggestion button is clicked
-        return function () {
-            select2Field.select2('close');
-            suggestionFieldFormGroup.collapse('show');
-            suggestionField.focus();
-        }
-    }
-
-}(this));
 
 $(document).ready(function () {
 
-    hideSuggestionField('financer_suggestion');
-    hideSuggestionField('instructor_suggestion');
-
     $('select#id_financers').select2({
         placeholder: catalog.financers_placeholder,
+        language: 'fr',
+        minimumInputLength: 2,
         ajax: {
             url: '/api/backers/',
             dataType: 'json',
@@ -62,23 +26,12 @@ $(document).ready(function () {
         },
         theme: 'bootstrap4',
         width: '',
-        language: {
-            noResults: function (term) {
-                var btn = $('<button />')
-                    .addClass('btn')
-                    .addClass('btn-link')
-                    .on('click', showSuggestionField('financers', 'financer_suggestion'))
-                    .html(catalog.suggest_backer_button);
-
-                var text = $('<span />')
-                    .html(catalog.no_backers_found);
-
-                return text.append(btn);
-            },
-        },
     });
+
     $('select#id_instructors').select2({
         placeholder: catalog.instructors_placeholder,
+        language: 'fr',
+        minimumInputLength: 2,
         ajax: {
             url: '/api/backers/',
             dataType: 'json',
@@ -96,19 +49,5 @@ $(document).ready(function () {
         },
         theme: 'bootstrap4',
         width: '',
-        language: {
-            noResults: function (term) {
-                var btn = $('<button />')
-                    .addClass('btn')
-                    .addClass('btn-link')
-                    .on('click', showSuggestionField('instructors', 'instructor_suggestion'))
-                    .html(catalog.suggest_backer_button);
-
-                var text = $('<span />')
-                    .html(catalog.no_backers_found);
-
-                return text.append(btn);
-            },
-        },
     });
 });

--- a/src/templates/aids/_base_edit.html
+++ b/src/templates/aids/_base_edit.html
@@ -40,8 +40,10 @@
         {% include '_field_snippet.html' with field=form.targeted_audiences %}
         {% include '_field_snippet.html' with field=form.financers %}
         {% include '_field_snippet.html' with field=form.financer_suggestion %}
-        {% include '_field_snippet.html' with field=form.instructors %}
-        {% include '_field_snippet.html' with field=form.instructor_suggestion %}
+        <div id="instructor-fields">
+            {% include '_field_snippet.html' with field=form.instructors %}
+            {% include '_field_snippet.html' with field=form.instructor_suggestion %}
+        </div>
     </fieldset>
 
     <fieldset>


### PR DESCRIPTION
Supprime le contrôle javascript qui affiche un lien quand aucun résultat n'est trouvé dans l'autocomplétion, et affiche un simple champ « suggérer un nouvel apporteur » dans le formulaire.