### PR TITLE
Import ADEME : bug sur le bénéficiaires pour certaines aides

### DIFF
--- a/src/aids/api/serializers.py
+++ b/src/aids/api/serializers.py
@@ -8,12 +8,10 @@ class ArrayField(serializers.ListField):
     child = serializers.CharField()
 
     def __init__(self, choices, *args, **kwargs):
-
         self.repr_dict = dict(choices)
         super().__init__(*args, **kwargs)
 
     def to_representation(self, obj):
-
         representation = [self.repr_dict[choice] for choice in obj]
         return representation
 
@@ -85,6 +83,7 @@ class AidSerializer11(BaseAidSerializer):
 
 
 class CategoryRelatedField(serializers.StringRelatedField):
+
     def to_representation(self, value):
         return f'{value.theme}|{value}'
 

--- a/src/dataproviders/management/commands/import_ademe.py
+++ b/src/dataproviders/management/commands/import_ademe.py
@@ -24,8 +24,8 @@ AUDIENCES_DICT = {
         Aid.AUDIENCES.region,
         Aid.AUDIENCES.epci,
     ],
-    'Particuliers et Eco-citoyens': Aid.AUDIENCES.private_person,
-    'Association': Aid.AUDIENCES.association,
+    'Particuliers et Eco-citoyens': [Aid.AUDIENCES.private_person],
+    'Association': [Aid.AUDIENCES.association],
     'Tout Public': [
         Aid.AUDIENCES.commune,
         Aid.AUDIENCES.department,


### PR DESCRIPTION
Parfois un string était concaténé à la liste des targeted_audiences

Ce qui provoquait des valeurs comme `['r', 'commune', '_', 'a', 'department', 'epci', 'o', 'private_sector', 't', 'private_person', 'n', 'p', 's', 'association', 'region', 'i', 'e', 'public_cies', 'researcher', 'v']`

Et in fine des erreurs lors d'appels API
https://sentry.io/organizations/aides-territoires-beta/issues/2167241639/?project=5506889&query=is%3Aunresolved