### PR TITLE
Amélioration du script d'export Matomo

### DIFF
--- a/src/analytics/management/commands/matomo_export_stats.py
+++ b/src/analytics/management/commands/matomo_export_stats.py
@@ -7,14 +7,16 @@ from datetime import datetime, timedelta
 from django.core.management.base import BaseCommand
 from django.utils.text import slugify
 
-from analytics.utils import get_matomo_page_urls_stats
+from analytics.utils import get_matomo_stats
 
 
+DEFAULT_MATOMO_API_METHOD = 'Actions.getPageUrls'
 DATE_FORMAT = '%Y-%m-%d'  # 2020-12-31
 KEYS_CONSIDERED = [
     'label',
     'nb_visits',  # nombre de visiteurs
-    'nb_hits'  # nombre de vues
+    'nb_hits',  # nombre de vues
+    'url' # useful for filtering
 ]
 AID_SEARCH_PARAMETERS = [
     'targeted_audiences',
@@ -29,13 +31,19 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     """
-    Reusable command to fetch/aggregate matomo page view stats.
+    Reusable command to fetch/aggregate matomo stats.
+
+    What kind of stats ?
+    https://developer.matomo.org/api-reference/reporting-api
+    - 'Actions.getPageUrls': views per page URL
+    - 'Actions.getPageTitles': views per page title
+    - 'Actions.getSiteSearchKeywords': keywords searched in the application
 
     Why step-by-step with small timeframes instead of 1 single call ?
     - Matomo aggregates results if there are too many, under "<page label> - Others"
     - Therefore we sum keys at each step
 
-    Day incrementation example :
+    Day incrementation example:
     2020-01-01 --> 2020-01-31 with 3 day increments
     - 2020-01-01 > 2020-01-04
     - 2020-01-05 > 2020-01-08
@@ -43,36 +51,58 @@ class Command(BaseCommand):
     - 2020-01-27 > 2020-01-30
     - 2020-01-31 > 2020-01-31
 
-    Usage :
-    pipenv run python manage.py matomo_export_getpageurls
-    pipenv run python manage.py matomo_export_getpageurls --page_label_prefix_filter '/recherche/formulaire/audience/'
-    pipenv run python manage.py matomo_export_getpageurls --page_label_prefix_filter '/aides/?'
-    pipenv run python manage.py matomo_export_getpageurls --start_date 2020-05-01
-    pipenv run python manage.py matomo_export_getpageurls --start_date 2020-05-01 --end_date 2020-05-31
-    pipenv run python manage.py matomo_export_getpageurls --start_date 2020-05-01 --end_date 2020-05-31 --increment_in_days 3
-    pipenv run python manage.py matomo_export_getpageurls --start_date 2020-05-01 --end_date 2020-05-31 --increment_in_days 0 (day by day)
+    Usage:
+    pipenv run python manage.py matomo_export_stats
+    pipenv run python manage.py matomo_export_stats --api_method Actions.getSiteSearchKeywords
+    pipenv run python manage.py matomo_export_stats --custom_segment 'pageUrl=@actioncoeurdeville.aides-territoires.beta.gouv.fr'
+    pipenv run python manage.py matomo_export_stats --page_url_prefix_filter 'https://actioncoeurdeville.aides-territoires.beta.gouv.fr/'
+    pipenv run python manage.py matomo_export_stats --page_label_prefix_filter '/recherche/formulaire/audience/'
+    pipenv run python manage.py matomo_export_stats --page_label_prefix_filter '/aides/?'
+    pipenv run python manage.py matomo_export_stats --start_date 2020-05-01
+    pipenv run python manage.py matomo_export_stats --start_date 2020-05-01 --end_date 2020-05-31
+    pipenv run python manage.py matomo_export_stats --start_date 2020-05-01 --end_date 2020-05-31 --increment_in_days 3
+    pipenv run python manage.py matomo_export_stats --start_date 2020-05-01 --end_date 2020-05-31 --increment_in_days 0 (day by day)
+    pipenv run python manage.py matomo_export_stats --custom_segment 'pageTitle==Aides-territoires | Recherche' --page_label_prefix_filter '/aides/?' --start_date 2020-05-25 --end_date 2020-12-31 --increment_in_days 0
+
+    TODO:
+    - sort csv before export ?
     """
 
     def add_arguments(self, parser):
         parser.add_argument(
+            '--api_method', type=str,
+            default=DEFAULT_MATOMO_API_METHOD,
+            help="Specify the Matomo API method. optional."
+        )
+        parser.add_argument(
+            '--custom_segment', type=str,
+            default="",
+            help="Specify a custom Matomo segment. optional."
+        )
+        parser.add_argument(
+            '--page_url_prefix_filter', type=str,
+            default="",
+            help="Filter results by a specific page url prefix. optional."
+        )
+        parser.add_argument(
             '--page_label_prefix_filter', type=str,
             default="",
-            help="filter results by a specific page label prefix. optional."
+            help="Filter results by a specific page label prefix. optional."
         )
         parser.add_argument(
             '--start_date', type=str,
             default="2020-01-01",
-            help="the range's start date. Use format YYY-MM-DD. optional."
+            help="The range's start date. Use format YYY-MM-DD. optional."
         )
         parser.add_argument(
             '--end_date', type=str,
             default="2020-12-31",
-            help="the range's end date. Use format YYY-MM-DD. optional."
+            help="The range's end date. Use format YYY-MM-DD. optional."
         )
         parser.add_argument(
             '--increment_in_days', type=int,
             default=None,
-            help="query the API by increments of X days. 0 = single query. optional."
+            help="Query the API by increments of X days. 0 = single query. optional."
         )
 
     def handle(self, *args, **options):
@@ -100,7 +130,9 @@ class Command(BaseCommand):
             temp_end_date_string = temp_end_datetime.strftime(DATE_FORMAT)
             self.stdout.write('...querying: {} to {}'.format(temp_start_date_string, temp_end_date_string))
 
-            data = get_matomo_page_urls_stats(
+            data = get_matomo_stats(
+                api_method=options['api_method'],
+                custom_segment=options['custom_segment'],
                 from_date_string=temp_start_date_string,
                 to_date_string=temp_end_date_string)
 
@@ -111,10 +143,9 @@ class Command(BaseCommand):
                 page = {k: v for k, v in page.items() if k in KEYS_CONSIDERED}
                 page['label'] = re.sub("audiance", "audience", page['label'], flags=re.IGNORECASE)
 
-                # process audience pages
-                if page['label'].startswith(options['page_label_prefix_filter']):
+                if page['label'].startswith(options['page_label_prefix_filter']) and page.get('url', '').startswith(options['page_url_prefix_filter']):
                     # notify if there are aggregated labels
-                    if " - Others" in page['label']:
+                    if "Others" in page['label']:
                         self.stdout.write(page['label'])
 
                     # sum existing label data
@@ -137,10 +168,13 @@ class Command(BaseCommand):
                 break
 
         # write dict to csv
-        keys = agg_dict_list[0].keys()
-        filename = f"matomo_getpageurls_{slugify(options['page_label_prefix_filter'])}_{options['start_date']}_{options['end_date']}.csv"
-        with open(filename, 'w', newline='') as output_file:
-            dict_writer = csv.DictWriter(output_file, fieldnames=keys, extrasaction='ignore')
-            dict_writer.writeheader()
-            dict_writer.writerows(agg_dict_list)
-            self.stdout.write(self.style.SUCCESS('File created: {}'.format(filename)))
+        if len(agg_dict_list):
+            keys = agg_dict_list[0].keys()
+            filename = f"matomo_{slugify(options['api_method'])}_{options['start_date']}_{options['end_date']}.csv"
+            with open(filename, 'w', newline='') as output_file:
+                dict_writer = csv.DictWriter(output_file, fieldnames=keys, extrasaction='ignore')
+                dict_writer.writeheader()
+                dict_writer.writerows(agg_dict_list)
+                self.stdout.write(self.style.SUCCESS('File created: {}'.format(filename)))
+        else:
+            self.stdout.write('Returned no results')

--- a/src/analytics/utils.py
+++ b/src/analytics/utils.py
@@ -57,25 +57,35 @@ def get_matomo_stats_from_page_title(page_title, from_date_string, to_date_strin
     return '-'
 
 
-def get_matomo_page_urls_stats(from_date_string, to_date_string=timezone.now().strftime('%Y-%m-%d')):  # noqa
+def get_matomo_stats(api_method, custom_segment='', from_date_string='2020-01-01', to_date_string=timezone.now().strftime('%Y-%m-%d')):  # noqa
     """
-    Get view stats of all Page Urls from Matomo.
+    Get stats of all Page Urls from Matomo.
     from_date_string & to_date_string must have YYYY-MM-DD format.
 
+    API Method examples:
+    - 'Actions.getPageUrls' (views per page url)
+    - 'Actions.getPageTitles' (views per page title)
+    - 'Actions.getSiteSearchKeywords' (keywords searched in the the application)
+
+    Custom segments examples:
+    https://developer.matomo.org/api-reference/reporting-api-segmentation
+    - 'pageUrl=@actioncoeurdeville.aides-territoires.beta.gouv.fr' (url must contain string)
+    - 'pageTitle==Aides-territoires | Recherche avancée'
+
     Usage example:
-    get_matomo_stats_from_page_title('2020-01-01', to_date_string='2020-12-31')
+    get_matomo_stats_from_page_title('Actions.getPageUrls', from_date_string='2020-01-01', to_date_string='2020-12-31')  # noqa
     """
-    MATOMO_API_METHOD = 'Actions.getPageUrls'
 
     params = {
         'idSite': settings.ANALYTICS_SITEID,
         'module': 'API',
-        'method': MATOMO_API_METHOD,
+        'method': api_method,
         'period': 'range',
         'date': f'{from_date_string},{to_date_string}',
         'flat': 1,
         'filter_limit': -1,
-        'format': 'json'
+        'format': 'json',
+        'segment': custom_segment,
     }
     res = requests.get(settings.ANALYTICS_ENDPOINT, params=params)
     data = res.json()


### PR DESCRIPTION
Rendre le script réutilisable pour plusieurs méthodes Matomo (et non juste PageUrls comme avant).
Ca m'a permis de récupérer getSiteSearchKeywords sur l'année 2020