### PR TITLE
Minisites: fix sur les urls des porteurs

### DIFF
--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -1387,6 +1387,12 @@ msgstr "<slug:token>/validation/"
 msgid "programs/<slug:slug>/"
 msgstr "programmes/<slug:slug>/"
 
+msgid "backers/<slug:slug>/"
+msgstr "partenaires/<slug:slug>/"
+
+msgid "backers/<int:pk>-<str>/"
+msgstr "partenaires/<int:pk>-<str>/"
+
 msgid "Content"
 msgstr "Contenu"
 

--- a/src/minisites/urls.py
+++ b/src/minisites/urls.py
@@ -49,12 +49,10 @@ urlpatterns = [
     path(_('programs/<slug:slug>/'), SiteProgram.as_view(),
          name='program_detail'),
 
-    path(
-        '<int:pk>/', SiteBackers.as_view(),
-        name='backer_detail_view'),
-    path(
-        '<int:pk>-<str>/', SiteBackers.as_view(),
-        name='backer_detail_view'),
+    path(_('backers/<int:pk>/'), SiteBackers.as_view(),
+         name='backer_detail_view'),
+    path(_('backers/<int:pk>-<str>/'), SiteBackers.as_view(),
+         name='backer_detail_view'),
 
     path(_('legal-mentions/'), SiteLegalMentions.as_view(),
          name='legal_mentions'),

--- a/src/templates/minisites/backer_detail.html
+++ b/src/templates/minisites/backer_detail.html
@@ -12,8 +12,8 @@
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
         <li><a href="{% url 'home' %}">{{ _('Home') }}</a></li>
-        <li class="active" aria-current="page">{{ _('Programs') }}</li>
-        <li class="active" aria-current="page">{{ program.name }}</li>
+        <li class="active" aria-current="page">{{ _('Backers') }}</li>
+        <li class="active" aria-current="page">{{ backer.name }}</li>
     </ol>
 </nav>
 {% endblock %}


### PR DESCRIPTION
Dans la continuité du hotfix de la dernière fois
https://github.com/MTES-MCT/aides-territoires/commit/c4c0e04262824114bcdaec470a0a41ab23cbe4eb#diff-c649d0f828ee7e96d1c279a4d1261f590dc07dfcfa00c5aef148569364a86298

Répare 
- url complètes des backers
- breadcrumbs sur le template d'un backer