### PR TITLE
Ajout d'une traduction manquante dans django.po

### DIFF
--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -2163,6 +2163,9 @@ msgstr "Plus de critères"
 msgid "Share this aid"
 msgstr "Partager cette aide"
 
+msgid "Copy the current url to clipboard"
+msgstr "Copier l'url dans le presse-papier"
+
 msgid "Advanced search"
 msgstr "Recherche avancée"
 


### PR DESCRIPTION
Ajout de la traduction de `Copy the current url to clipboard` perdue lors du merge précédent.