### PR TITLE
Selection périmètres cachés depuis formulaire de création d'aide

### DIFF
--- a/src/static/js/aids/perimeter_autocomplete.js
+++ b/src/static/js/aids/perimeter_autocomplete.js
@@ -1,4 +1,8 @@
 $(document).ready(function () {
+
+    // hide "custom" perimeters in the user part of the website
+    var RESTRICT_TO_VISIBLE_PERIMETERS = $('#perimeter').length || $('#search-form').length || $('#advanced-search-form').length;
+
     $('select#id_perimeter').select2({
         placeholder: catalog.perimeter_placeholder,
         language: 'fr',
@@ -13,7 +17,7 @@ $(document).ready(function () {
             data: function (params) {
                 var query = {
                   q: params.term,
-                  is_visible_to_users: true,
+                  is_visible_to_users: RESTRICT_TO_VISIBLE_PERIMETERS ? true : false,
                 }
                 return query;
             },

--- a/src/templates/aids/advanced_search.html
+++ b/src/templates/aids/advanced_search.html
@@ -19,7 +19,7 @@
 {% block content %}
 <div class="article">
     <h1>{{ _('More search filters') }}</h1>
-    <form method="get" action="{% url 'search_view' %}">
+    <form id="advanced-search-form" method="get" action="{% url 'search_view' %}">
         {% for field in form.hidden_fields %}
             {{ field }}
         {% endfor %}


### PR DESCRIPTION
Certains périmètres "custom" ont été cachés de l'autocomplete dans https://github.com/MTES-MCT/aides-territoires/pull/384
Mais on souhaite quand même tous les avoirs dans les parties admin & porteurs du site.
Du coup l'action de filtrage a lieu seulement sur la partie utilisateur du site (étape 2 de la recherche, formulaire de recherche & recherche avancées)