### PR TITLE
Log d'email alerte : utiliser sentry plutôt que actstream

### DIFF
--- a/src/Pipfile.lock
+++ b/src/Pipfile.lock
@@ -602,11 +602,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:1411dc3c26dfbfb55b88d8239484b2f2a9df4e69e67965711b187c8917bff872",
-                "sha256:4ccd91f540ef57732d38451889b915ab75a78e04f427e9f2811ff9da0332a174"
+                "sha256:0fa02fa80363844a4ab4b8d6891f62dd0645ba672723130423ca4037b80c1974",
+                "sha256:62c811e46bd09130fb11ab759012a4ae385ce4fb2073442d1898867a824183bd"
             ],
             "markers": "python_full_version >= '3.6.1'",
-            "version": "==3.0.15"
+            "version": "==3.0.16"
         },
         "protego": {
             "hashes": [
@@ -865,11 +865,11 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:0a711ec952441c2ec89b8f5d226c33bc697914f46e876b44a4edd3e7864cf4d0",
-                "sha256:737a094e49a529dd0fdcaafa9e97cf7c3d5eb964bd229821d640bc77f3502b3f"
+                "sha256:012f2c8f40a504e2d68d045f72a2fd63814acb61ea6db5014df75573077b5ceb",
+                "sha256:31871a1c18547cafa7b75064c6391aa517b15468fda7b644ccb149decccb9d44"
             ],
             "index": "pypi",
-            "version": "==0.19.5"
+            "version": "==0.20.0"
         },
         "service-identity": {
             "hashes": [
@@ -1403,11 +1403,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:1411dc3c26dfbfb55b88d8239484b2f2a9df4e69e67965711b187c8917bff872",
-                "sha256:4ccd91f540ef57732d38451889b915ab75a78e04f427e9f2811ff9da0332a174"
+                "sha256:0fa02fa80363844a4ab4b8d6891f62dd0645ba672723130423ca4037b80c1974",
+                "sha256:62c811e46bd09130fb11ab759012a4ae385ce4fb2073442d1898867a824183bd"
             ],
             "markers": "python_full_version >= '3.6.1'",
-            "version": "==3.0.15"
+            "version": "==3.0.16"
         },
         "ptyprocess": {
             "hashes": [

--- a/src/alerts/management/commands/send_alerts.py
+++ b/src/alerts/management/commands/send_alerts.py
@@ -3,6 +3,8 @@
 from datetime import timedelta
 import logging
 
+from sentry_sdk import capture_exception
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
@@ -11,8 +13,6 @@ from django.db.models import Q, Case, When
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
-
-from actstream import action
 
 from stats.utils import log_event
 from alerts.models import Alert
@@ -112,14 +112,4 @@ class Command(BaseCommand):
                 html_message=html_body,
                 fail_silently=False)
         except Exception as e:
-            # We log, only in case there is an issue.
-            log_details = {
-                'sender': site,
-                'action_object': alert,
-                'verb': 'alert-email-not-sent',
-                'action_target': alert.email,
-                'description': f'To: {alert.email}\n'
-                               f'From: {email_from}\n'
-                               f'{e}'
-                }
-            action.send(**log_details)
+            capture_exception(e)


### PR DESCRIPTION
Suite de https://github.com/MTES-MCT/aides-territoires/pull/430

@lazybird j'ai laissé ActStream. Je te laisse me dire si on laisse le packet + l'app, ou si on enlève tout