### PR TITLE
Fix l'affichage du titre et du logo sur les pages backer-detail

### DIFF
--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -1436,7 +1436,7 @@ div#search-steps {
     }
 }
 
-#backer-title {
+#backer-title > div {
     @extend .row;
 
     h1 {

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -1437,14 +1437,21 @@ div#search-steps {
 }
 
 #backer-title {
-    @extend .d-flex;
-    @extend .flex-row;
-    @extend .flex-wrap;
-    @extend .justify-content-between;
+    @extend .row;
+
+    h1 {
+        @extend .col-md-10;
+    }
+
+    div {
+        @extend .col-md-2;
+    }
 
     img {
         max-height: $height-img-base;
         max-width: 300px;
+        display: block;
+        margin: auto;
     }
 }
 

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -1439,11 +1439,11 @@ div#search-steps {
 #backer-title > div {
     @extend .row;
 
-    h1 {
+    & div:first-of-type {
         @extend .col-md-10;
     }
 
-    div {
+    & div:last-of-type {
         @extend .col-md-2;
     }
 

--- a/src/templates/backers/detail.html
+++ b/src/templates/backers/detail.html
@@ -21,7 +21,9 @@
         <div id="backer-title">
             <h1>{{ backer.name }}</h1>
             {% if backer.logo %}
-            <img src="{{ backer.logo.url }}" alt="logo du porteur {{ backer.name }}">
+            <div>
+                <img src="{{ backer.logo.url }}" alt="logo du porteur {{ backer.name }}">
+            </div>
             {% endif %}
         </div> 
 

--- a/src/templates/backers/detail.html
+++ b/src/templates/backers/detail.html
@@ -21,12 +21,12 @@
         <div id="backer-title">
             {% if backer.logo %}
             <div>
-                <h1>{{ backer.name }}</h1>
-                {% if backer.logo %}
+                <div>
+                    <h1>{{ backer.name }}</h1>
+                </div>
                 <div>
                     <img src="{{ backer.logo.url }}" alt="logo du porteur {{ backer.name }}">
                 </div>
-                {% endif %}
             </div>
             {% else %}
                 <h1>{{ backer.name }}</h1>

--- a/src/templates/backers/detail.html
+++ b/src/templates/backers/detail.html
@@ -19,11 +19,17 @@
     <section id="backer-content">
 
         <div id="backer-title">
-            <h1>{{ backer.name }}</h1>
             {% if backer.logo %}
             <div>
-                <img src="{{ backer.logo.url }}" alt="logo du porteur {{ backer.name }}">
+                <h1>{{ backer.name }}</h1>
+                {% if backer.logo %}
+                <div>
+                    <img src="{{ backer.logo.url }}" alt="logo du porteur {{ backer.name }}">
+                </div>
+                {% endif %}
             </div>
+            {% else %}
+                <h1>{{ backer.name }}</h1>
             {% endif %}
         </div> 
 


### PR DESCRIPTION
https://trello.com/c/3WJKMGeM/982-fixer-laffichage-du-titre-et-du-logo-sur-les-pages-porteurs-daides

Sur la page détail porteur, quand le nom du porteur était trop long, le logo en face se plaçait sans élégance en dessous. 

Fix ce problème en utilisant la grid bootstrap. 