### PR TITLE
Certaines aides locales sont exclues par erreur sur les PP

### DIFF
--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -721,7 +721,7 @@ class BaseAidSearchForm(forms.Form):
             # over excluding the local aid.
             if search_smaller:
                 aids_to_exclude.append(aid.generic_aid.pk)
-            elif search_wider:
+            elif search_wider and aid.generic_aid in qs:
                 # If the search perimeter is wider than the local perimeter
                 # then it more relevant to keep the generic aid and exclude the
                 # the local one.


### PR DESCRIPTION
Avec ce changement, on rajoute des requêtes supplémentaires à la recherche, mais c'est pour s'assurer qu'on n'exclue pas des aides locales alors que leur version générique est absente.