### PR TITLE
Possibilité de forcer l'ouverture des liens externes dans un nouvel onglet

### DIFF
--- a/src/dataproviders/utils.py
+++ b/src/dataproviders/utils.py
@@ -7,7 +7,8 @@ ALLOWED_TAGS = [
     'p', 'ul', 'ol', 'li', 'strong', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
     'br',
 ]
-ALLOWED_ATTRS = ['href', 'src', 'alt', 'width', 'height', 'style', 'target', 'rel']
+ALLOWED_ATTRS = ['href', 'src', 'alt', 'width', 'height', 'style', 'target',
+                 'rel']
 
 
 def content_prettify(raw_text, more_allowed_tags=[], more_allowed_attrs=[]):

--- a/src/dataproviders/utils.py
+++ b/src/dataproviders/utils.py
@@ -7,7 +7,7 @@ ALLOWED_TAGS = [
     'p', 'ul', 'ol', 'li', 'strong', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
     'br',
 ]
-ALLOWED_ATTRS = ['href', 'src', 'alt', 'width', 'height', 'style']
+ALLOWED_ATTRS = ['href', 'src', 'alt', 'width', 'height', 'style', 'target', 'rel']
 
 
 def content_prettify(raw_text, more_allowed_tags=[], more_allowed_attrs=[]):

--- a/src/dataproviders/utils.py
+++ b/src/dataproviders/utils.py
@@ -7,8 +7,8 @@ ALLOWED_TAGS = [
     'p', 'ul', 'ol', 'li', 'strong', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
     'br',
 ]
-ALLOWED_ATTRS = ['href', 'src', 'alt', 'width', 'height', 'style', 'target',
-                 'rel']
+ALLOWED_ATTRS = ['href', 'src', 'alt', 'width', 'height', 'style',
+                 'target', 'rel']  # for links opening in a new tab
 
 
 def content_prettify(raw_text, more_allowed_tags=[], more_allowed_attrs=[]):


### PR DESCRIPTION
https://trello.com/c/Cmn8Qf6r/969-ouverture-des-liens-externes-dans-un-nouvel-onglet

On permet dans l'admin de forcer l'ouverture du lien dans un nouvel onglet. L'ouverture du lien sur la même page restera tout de même le comportement par défaut. Il faudra cliquer sur "visualiser le html" puis ajouter dans la balise <a> `target="_blank" rel="noopener"` pour que le lien change de comportement. 