### PR TITLE
supprimer l'affichage des programmes dans la liste de résultats des aides

### DIFF
--- a/src/templates/aids/_results.html
+++ b/src/templates/aids/_results.html
@@ -1,13 +1,7 @@
 {% load i18n %}
 
-{% if aids or programs %}
+{% if aids %}
     <div class="aids">
-    {% for program in programs %}
-        <div class="col">
-            {% include 'programs/_program_result.html' with program=program %}
-        </div>
-    {% endfor %}
-
     {% for aid in aids %}
         <div class="col">
             {% include 'aids/_aid_result.html' with aid=aid %}


### PR DESCRIPTION
Historiquement l'affichage des programmes parmis les résultats des aides était prévu dans le template `_results.html. `

L'affichage n'était cependant pas effectif car programs n'était pas servi par SearchView. 

Avec l'ajout de `context['programs']` dans la `def get_context_data`, les programmes se retrouvent effectivement affichés. 

On modifie le template` _results.html` pour supprimer l'affichage des programmes dans la liste des résultats des aides.