### PR TITLE
Ajout des params 'action' dans les étapes de recherches

### DIFF
--- a/src/templates/search/step_audience.html
+++ b/src/templates/search/step_audience.html
@@ -47,7 +47,7 @@
     {% include '_form_snippet.html' %}
 
     <div class="navigation-links">
-        <a class="next-btn" href="{% url 'search_step_perimeter' %}">
+        <a class="next-btn" href="{% url 'search_step_perimeter' %}?action=search">
             {{ _('Skip to the next step') }}
         </a>
     </div>

--- a/src/templates/search/step_perimeter.html
+++ b/src/templates/search/step_perimeter.html
@@ -48,7 +48,7 @@
 
     {% include '_form_snippet.html' %}
 
-    <button type="submit">
+    <button name="action" value="search" type="submit">
         {{ _('Submit') }}
     </button>
 

--- a/src/templates/search/step_project.html
+++ b/src/templates/search/step_project.html
@@ -57,32 +57,34 @@
 {% block content %}
 <h1>{{ _('In what projects are you interested in&nbsp;?') }}</h1>
 
-        <div id="suggested_project_box">
-            <h3>{{ _('Contribute to improve Aides-territoires&nbsp;!') }}</h3>
-            <div class="info">
-                <p>{{ _('Tell us the project for which you are seeking aids.') }}</p>
-                <p>{{ _('This will help us to improve in future the relevance of results') }}</p>
-            </div>
-            <form id="suggested_project" method="post" action="{% url 'project_suggest_view' %}?{{ querystring }}">
-                <div class="content">
-                {% csrf_token %}
-                {% include '_field_snippet.html' with field=project_form.name %}
-                {% include '_field_snippet.html' with field=project_form.description %}
-                <div class="warning">
-                    <p>{{ _('These informations will not have any impact in your search results and will stay confidential') }}</p>
-                </div> 
-                <button type="submit">{{ _('Submit this project and display results') }}</button>
-                </div>
-            </form>
+<div id="suggested_project_box">
+    <h3>{{ _('Contribute to improve Aides-territoires&nbsp;!') }}</h3>
+    <div class="info">
+        <p>{{ _('Tell us the project for which you are seeking aids.') }}</p>
+        <p>{{ _('This will help us to improve in future the relevance of results') }}</p>
+    </div>
+    <form id="suggested_project" method="post" action="{% url 'project_suggest_view' %}?{{ querystring }}">
+        <div class="content">
+            {% csrf_token %}
+            {% include '_field_snippet.html' with field=project_form.name %}
+            {% include '_field_snippet.html' with field=project_form.description %}
+            <div class="warning">
+                <p>{{ _('These informations will not have any impact in your search results and will stay confidential') }}</p>
+            </div> 
+            <button name="action" value="search" type="submit">
+                {{ _('Submit this project and display results') }}
+            </button>
         </div>
-        <div class="navigation-links">
-            <a id="next-btn" href="{% url 'search_view' %}?{{ querystring }}">
-                {{ _('Skip to the next step') }}
-            </a>
-            <a class="previous-btn" href="{% url 'search_step_category' %}?{{ querystring }}">
-                {{ _('Back to previous step') }}
-            </a>
-        </div>
+    </form>
+</div>
+<div class="navigation-links">
+    <a id="next-btn" href="{% url 'search_view' %}?{{ querystring }}">
+        {{ _('Skip to the next step') }}
+    </a>
+    <a class="previous-btn" href="{% url 'search_step_category' %}?{{ querystring }}">
+        {{ _('Back to previous step') }}
+    </a>
+</div>
 {% endblock %}
 
 {% block extra_js %}

--- a/src/templates/search/step_theme.html
+++ b/src/templates/search/step_theme.html
@@ -50,7 +50,7 @@
 
     {% include '_form_snippet.html' %}
 
-    <button type="submit">
+    <button name="action" value="search" type="submit">
         {{ _('Submit') }}
     </button>
 


### PR DESCRIPTION
Il manquait quelques `action=search` sur certaines étapes du formulaire de recherche.
Ca permettra un jour de filtrer les stats de recherche par `search` (formulaire), `search-filter` (cartouche), `search-details` (filtres avancés)