### PR TITLE
Ajout des tags Sendinblue pour les emails d'alerte

### DIFF
--- a/src/accounts/tasks.py
+++ b/src/accounts/tasks.py
@@ -9,7 +9,7 @@ from django.conf import settings
 
 from accounts.models import User
 from core.celery import app
-from emails.utils import send_template_email
+from emails.utils import send_email_with_template
 
 
 LOGIN_SUBJECT = 'Connexion à Aides-territoires'
@@ -74,7 +74,7 @@ def send_welcome_email(user_email):
         'PRENOM': user.first_name,
         'NOM': user.last_name,
     }
-    send_template_email(
+    send_email_with_template(
         recipient_list=[user_email],
         template_id=settings.SIB_WELCOME_EMAIL_TEMPLATE_ID,
         data=data,

--- a/src/aids/tasks.py
+++ b/src/aids/tasks.py
@@ -5,7 +5,7 @@ from django.template.loader import render_to_string
 
 from core.celery import app
 from django.apps import apps
-from emails.utils import send_template_email
+from emails.utils import send_email_with_template
 
 
 @app.task
@@ -46,7 +46,7 @@ def send_publication_email(aid_id):
         'AIDE_URL': aid.get_absolute_url(),
         'BASE_URL': base_url,
     }
-    send_template_email(
+    send_email_with_template(
         recipient_list=[author.email],
         template_id=settings.SIB_PUBLICATION_EMAIL_TEMPLATE_ID,
         data=data,

--- a/src/alerts/management/commands/send_alerts.py
+++ b/src/alerts/management/commands/send_alerts.py
@@ -13,10 +13,10 @@ from django.db.models import Q, Case, When
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
-from django.core.mail import send_mail
 
 from stats.utils import log_event
 from alerts.models import Alert
+from emails.utils import send_email
 
 
 logger = logging.getLogger(__name__)
@@ -104,12 +104,13 @@ class Command(BaseCommand):
         email_from = settings.DEFAULT_FROM_EMAIL
         email_to = [alert.email]
         try:
-            send_mail(
-                email_subject,
-                text_body,
-                email_from,
-                email_to,
-                html_message=html_body,
+            send_email(
+                subject=email_subject,
+                body=text_body,
+                recipient_list=email_to,
+                from_email=email_from,
+                html_body=html_body,
+                tags=['alerte', settings.ENV_NAME],
                 fail_silently=False)
         except Exception as e:
             capture_exception(e)

--- a/src/alerts/tasks.py
+++ b/src/alerts/tasks.py
@@ -4,11 +4,11 @@ from django.urls import reverse
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from django.http import QueryDict
-from django.core.mail import send_mail
 
 from core.celery import app
 from aids.forms import AidSearchForm
 from alerts.models import Alert
+from emails.utils import send_email
 
 TEMPLATE = 'emails/alert_validate.txt'
 
@@ -54,16 +54,17 @@ def send_alert_confirmation_email(user_email, alert_token):
     else:
         frequency = _('You will receive a weekly email whenever new matching aids will be published.')  # noqa
 
-    email_body = render_to_string(TEMPLATE, {
+    text_body = render_to_string(TEMPLATE, {
         'base_url': base_url,
         'alert': alert,
         'frequency': frequency,
         'perimeter': perimeter,
         'alert_validation_link': '{}{}'.format(base_url, alert_validation_link)
     })
-    send_mail(
-        subject,
-        email_body,
-        settings.DEFAULT_FROM_EMAIL,
-        [user_email],
+    send_email(
+        subject=subject,
+        body=text_body,
+        recipient_list=[user_email],
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        tags=['alerte_confirmation', settings.ENV_NAME],
         fail_silently=False)

--- a/src/emails/utils.py
+++ b/src/emails/utils.py
@@ -25,7 +25,7 @@ def send_email(
     message.send(fail_silently=fail_silently)
 
 
-def send_template_email(
+def send_email_with_template(
         recipient_list, template_id, data=None, tags=None,
         fail_silently=False):
     """Use the "template" feature provided by our ESP"""

--- a/src/emails/utils.py
+++ b/src/emails/utils.py
@@ -1,4 +1,28 @@
+from django.conf import settings
+
 from anymail.message import AnymailMessage
+
+
+def send_email(
+        subject, body, recipient_list,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        html_body=None, tags=None,
+        fail_silently=False):
+    message = AnymailMessage(
+        subject=subject,
+        body=body,
+        to=recipient_list)
+
+    message.from_email = from_email
+
+    if html_body:
+        message.attach_alternative(html_body, 'text/html')
+
+    # Tags can then be found and filtered in the ESP's analytics dashboard
+    if tags:
+        message.tags = tags
+
+    message.send(fail_silently=fail_silently)
 
 
 def send_template_email(

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -1084,7 +1084,7 @@ msgid "delete/"
 msgstr "supprimer/"
 
 msgid "We just sent you an email to validate your alert."
-msgstr "Nous venons d'envoyer un e-mail pour valider votre alerte."
+msgstr "Nous venons de vous envoyer un e-mail afin de valider votre alerte."
 
 msgid "We could not create your alert because of those errors: {}"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgstr ""
 "votre liste d'alertes.</a>"
 
 msgid "We just sent you an email to validate your address."
-msgstr "Nous venons d'envoyer un e-mail pour valider votre adresse."
+msgstr "Nous venons de vous envoyer un e-mail afin de valider votre adresse."
 
 msgid "We could not create your bookmark because of those errors: {}"
 msgstr ""


### PR DESCRIPTION
Tags définis : 
- `alerte` pour `send_alert()`
- `alerte_confirmation` pour `send_alert_confirmation_email()`

Modifications apportées : 
- nouvelle méthode `send_email()` qui utilise AnyMail derrière
- renommage de `send_template_email()` en `send_email_with_template()` 😬 