### PR TITLE
Répare l'affichage d'aides qui ont des choices vide

### DIFF
--- a/src/aids/templatetags/aids.py
+++ b/src/aids/templatetags/aids.py
@@ -18,7 +18,9 @@ def choices_display(obj, field):
     choices = obj._meta.get_field(field).base_field.choices
     choices_dict = dict(choices)
 
-    keys = getattr(obj, field)
+    # set to empty list if None
+    keys = getattr(obj, field) or []
+
     values = [force_str(choices_dict.get(key, '')) for key in keys]
     return ', '.join(filter(None, values))
 


### PR DESCRIPTION
Certaines aides (en brouillon, importées par exemple) ont `aid_types = None`
Ce qui fait planter le template lorsqu'on souhaite les afficher à partir de l'admin
Exemple : https://staging.aides-territoires.beta.gouv.fr/aides/be29-aide-au-developpement-des-cooperatives-dactiv/