### PR TITLE
Eviter des erreurs de matching de Périmètres pour les stats de recherches

### DIFF
--- a/src/search/tests/test_utils.py
+++ b/src/search/tests/test_utils.py
@@ -7,6 +7,9 @@ from search.utils import (
 # get_querystring_themes, get_querystring_categories)
 
 
+pytestmark = pytest.mark.django_db
+
+
 querystring_testset = [
     ('', ''),  # expecting nothing
     ('drafts=True&call_for_projects_only=False', 'drafts=True&call_for_projects_only=False'),  # noqa
@@ -62,7 +65,8 @@ def test_get_querystring_value_list_from_key(input_querystring, key, expected_ou
 querystring_testset = [
     ('', None),
     ('drafts=True', None),
-    ('perimeter=', None)
+    ('perimeter=', None),
+    ('perimeter=abc', None),
 ]
 
 
@@ -70,3 +74,9 @@ querystring_testset = [
 def test_get_querystring_perimeter(input_querystring, expected_output):  # noqa
 
     assert get_querystring_perimeter(input_querystring) == expected_output  # noqa
+
+
+def test_get_querystring_perimeter_with_fixture(perimeters):
+    assert get_querystring_perimeter('perimeter=france') is None
+    assert get_querystring_perimeter(f"perimeter={perimeters['france'].id}") == perimeters['france']  # noqa
+    assert get_querystring_perimeter(f"perimeter={perimeters['france'].id}-france") == perimeters['france']  # noqa

--- a/src/search/utils.py
+++ b/src/search/utils.py
@@ -47,8 +47,11 @@ def get_querystring_perimeter(querystring):
     PERIMETER_KEY = 'perimeter'
     perimeter_list = get_querystring_value_list_from_key(querystring, PERIMETER_KEY)  # noqa
     if len(perimeter_list):
-        perimeter_id_str = perimeter_list[0].split('-')[0]
-        return Perimeter.objects.get(id=perimeter_id_str)
+        try:
+            perimeter_id_str = perimeter_list[0].split('-')[0]
+            return Perimeter.objects.get(id=perimeter_id_str)
+        except Exception:
+            return None
     else:
         return None
 


### PR DESCRIPTION
Parfois il y a des querystring qui contiennent des périmètres au mauvais format. Modification pour fail silently lors du matching de Périmètre.

Exemple de bug remonté : https://sentry.io/organizations/aides-territoires-beta/issues/2252581325/