### PR TITLE
Répare le stockage du champ 'text' du modèle AidSearchEvent

### DIFF
--- a/src/stats/migrations/0009_aidsearchevent_populate_text.py
+++ b/src/stats/migrations/0009_aidsearchevent_populate_text.py
@@ -8,7 +8,8 @@ from search.utils import get_querystring_value_from_key
 def populate_aidsearchevent_text(apps, schema_editor):
     AidSearchEvent = apps.get_model('stats', 'AidSearchEvent')
     for event in AidSearchEvent.objects.all():
-        event.text = get_querystring_value_from_key(event.querystring, 'text')
+        event_text = get_querystring_value_from_key(event.querystring, 'text')
+        event.text = event_text[:256]
         event.save()
 
 

--- a/src/stats/utils.py
+++ b/src/stats/utils.py
@@ -36,6 +36,7 @@ def log_aidsearchevent(querystring='', source='', results_count=0):
         targeted_audiences = get_querystring_value_list_from_key(querystring, 'targeted_audiences') or None  # noqa
         perimeter = get_querystring_perimeter(querystring)
         text = get_querystring_value_from_key(querystring, 'text')
+        text_cleaned = text[:256]
 
         event = AidSearchEvent.objects.create(
             querystring=querystring_cleaned,
@@ -43,7 +44,7 @@ def log_aidsearchevent(querystring='', source='', results_count=0):
             results_count=results_count,
             targeted_audiences=targeted_audiences,
             perimeter=perimeter,
-            text=text)
+            text=text_cleaned)
 
         themes = get_querystring_themes(querystring)
         categories = get_querystring_categories(querystring)


### PR DESCRIPTION
S'assurer que les valeurs du champ `text` sont au max 256 chars