### PR TITLE
Bug: ajout du champ france_relance.as_hidden dans le formulaire d'aide

### DIFF
--- a/src/templates/aids/_base_edit.html
+++ b/src/templates/aids/_base_edit.html
@@ -35,6 +35,7 @@
     <fieldset>
             <legend><span id="aid-presentation"></span>1 - {{ _('Aid presentation') }}</legend>
             {% include '_field_snippet_aid_form.html' with field=form.name %}
+            {% include '_checkbox_snippet.html' with field=form.in_france_relance.as_hidden %}
             {% include '_field_snippet_aid_form.html' with field=form.programs %}
             {% include '_field_snippet_aid_form.html' with field=form.financers %}
             {% include '_field_snippet_aid_form.html' with field=form.financer_suggestion %}


### PR DESCRIPTION
Suite à la refonte du formulaire d'aide il a été décidé de supprimer le `field` `france_relance` dans le formulaire.  

Mais certaines aides ont besoin de continuer à être tagguées "France Relance" (ex: le site du MTFP utilise ce champ pour filtrer les aides). 

On ajoute donc le champ` france_relance` en champ caché dans le formulaire pour permettre l'édition des aides déjà crées sans perte du tag.  