### PR TITLE
Affiche le nombre d'aides publiées par le même auteur

### DIFF
--- a/src/accounts/admin.py
+++ b/src/accounts/admin.py
@@ -5,6 +5,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 
+from aids.models import Aid
 from accounts.models import User
 
 
@@ -71,6 +72,21 @@ class UserAdmin(BaseUserAdmin):
 
     def get_changelist_form(self, request, **kwargs):
         return UserAdminForm
+
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        """Add aids by same author in context."""
+
+        other_aids = Aid.objects \
+            .existing() \
+            .filter(author_id=object_id) \
+            .prefetch_related('financers') \
+            .order_by('-date_published')
+
+        context = extra_context or {}
+        context['other_aids'] = other_aids
+
+        return super().change_view(
+            request, object_id, form_url=form_url, extra_context=context)
 
 
 admin.site.register(User, UserAdmin)

--- a/src/aids/admin.py
+++ b/src/aids/admin.py
@@ -1,7 +1,7 @@
 from functools import reduce
 from operator import and_
 
-from django.db.models import Q, CharField, Count, Value as V
+from django.db.models import Q, CharField, Value as V
 from django.db.models.functions import Concat
 from django.contrib import admin
 from django.contrib.admin.views.main import ChangeList
@@ -198,7 +198,6 @@ class BaseAidAdmin(ImportMixin, ExportActionMixin, admin.ModelAdmin):
             'fields': (
                 'name',
                 'slug',
-                'sibling_aids',
                 'in_france_relance',
                 'short_title',
                 'categories',
@@ -208,6 +207,7 @@ class BaseAidAdmin(ImportMixin, ExportActionMixin, admin.ModelAdmin):
                 'instructors',
                 'instructor_suggestion',
                 'author',
+                'sibling_aids',
             )
         }),
 

--- a/src/aids/admin.py
+++ b/src/aids/admin.py
@@ -1,7 +1,7 @@
 from functools import reduce
 from operator import and_
 
-from django.db.models import Q, CharField, Value as V
+from django.db.models import Q, CharField, Count, Value as V
 from django.db.models.functions import Concat
 from django.contrib import admin
 from django.contrib.admin.views.main import ChangeList
@@ -189,7 +189,7 @@ class BaseAidAdmin(ImportMixin, ExportActionMixin, admin.ModelAdmin):
 
     filter_vertical = ['categories']  # Overriden in the widget definition
     readonly_fields = [
-        'is_imported', 'import_uniqueid', 'import_data_url',
+        'sibling_aids', 'is_imported', 'import_uniqueid', 'import_data_url',
         'import_share_licence', 'import_last_access', 'date_created',
         'date_updated', 'date_published']
     raw_id_fields = ['generic_aid']
@@ -198,6 +198,7 @@ class BaseAidAdmin(ImportMixin, ExportActionMixin, admin.ModelAdmin):
             'fields': (
                 'name',
                 'slug',
+                'sibling_aids',
                 'in_france_relance',
                 'short_title',
                 'categories',
@@ -280,6 +281,23 @@ class BaseAidAdmin(ImportMixin, ExportActionMixin, admin.ModelAdmin):
             )
         }),
     ]
+
+    def sibling_aids(self, aid):
+        """Number of other (non draft) aids created by the same author."""
+
+        return Aid.objects \
+            .exclude(id=aid.id) \
+            .filter(author=aid.author) \
+            .filter(status__in=('reviewable', 'published')) \
+            .count()
+    sibling_aids.short_description = _('From the same author')
+    sibling_aids.help_text = _('Nb of (non-draft) aids by the same author')
+
+    def get_form(self, request, obj=None, **kwargs):
+        """Set readonly fields help texts."""
+        help_texts = {'sibling_aids': self.sibling_aids.help_text}
+        kwargs.update({'help_texts': help_texts})
+        return super().get_form(request, obj, **kwargs)
 
     def author_name(self, aid):
         return aid.author.full_name

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -222,6 +222,12 @@ msgstr "Données liées à l'import"
 msgid "Misc data"
 msgstr "Données diverses"
 
+msgid "From the same author"
+msgstr "Du même auteur"
+
+msgid "Nb of (non-draft) aids by the same author"
+msgstr "Nb. d'autres aides (sauf brouillons) créées par le même utilisateur"
+
 msgid "Financers"
 msgstr "Porteur·s d’aides"
 

--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -2033,6 +2033,12 @@ msgstr ""
 "Si vous n'arrivez pas à vous inscrire, <a href=\"mailto:aides-"
 "territoires@beta.gouv.fr\">n'hésitez pas à nous contacter</a>."
 
+msgid "Aids by this author"
+msgstr "Aides par cet auteur"
+
+msgid "There are no related aids"
+msgstr "Il n'y a pas d'aides à afficher"
+
 msgid "Amendment merge"
 msgstr "Intégration d'amendement"
 

--- a/src/templates/admin/accounts/user/change_form.html
+++ b/src/templates/admin/accounts/user/change_form.html
@@ -1,0 +1,32 @@
+{% extends 'admin/change_form.html' %}
+
+{% block after_field_sets %}
+<div class="inline-group">
+    <fieldset>
+        <h2>{{ _('Aids by this author') }} ({{ other_aids.count }})</h2>
+
+        {% if other_aids %}
+            <table>
+                <thead>
+                    <th>Aide</th>
+                    <th>Statut</th>
+                    <th>Première date de publication</th>
+                    <th>Porteur·s d’aides</th>
+                </thead>
+                <tbody>
+                    {% for aid in other_aids %}
+                    <tr>
+                        <td><a href="{{ aid.get_admin_url }}">{{ aid }}</a></td>
+                        <td>{{ aid.get_status_display }}</td>
+                        <td>{{ aid.date_published|default_if_none:'' }}</td>
+                        <td>{{ aid.financers.all|join:" / " }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <div>{{ _('There are no related aids') }}</div>
+        {% endif %}
+    </fieldset>
+</div>
+{% endblock %}


### PR DESCRIPTION
Dans l'admin, affiche un compteur qui indique le nombre d'aides (en revues ou publiées) par le même auteur.
Affiche également la liste de ces aides.