### PR TITLE
Mise à jour du buildpack python pour Scalingo

### DIFF
--- a/src/.buildpacks
+++ b/src/.buildpacks
@@ -1,3 +1,3 @@
 https://github.com/Scalingo/apt-buildpack.git
 https://github.com/Scalingo/nodejs-buildpack.git
-https://github.com/lazybird/python-buildpack.git#pip21
+https://github.com/Scalingo/python-buildpack.git


### PR DESCRIPTION
Nous étions en attente de cette mise à jour qui a été mergée : https://github.com/Scalingo/python-buildpack/issues/14