### PR TITLE
Ajoute la possibilité d'exporter les porteurs avec le nombre d'aides financées et/ou instruites

### DIFF
--- a/src/aids/resources.py
+++ b/src/aids/resources.py
@@ -73,6 +73,12 @@ class AidResource(resources.ModelResource):
         # adding custom widgets breaks the usual order
         export_order = [field.name for field in Aid._meta.fields if field.name not in AIDS_EXPORT_EXCLUDE_FIELDS]  # noqa
 
+    def get_import_fields(self):
+        return [field for field in self.get_fields() if field.column_name not in AIDS_IMPORT_EXCLUDE_FIELDS]  # noqa
+
+    def get_user_visible_fields(self):
+        return [field for field in self.get_fields() if field.column_name not in AIDS_IMPORT_EXCLUDE_FIELDS]  # noqa
+
     def before_import_row(self, row, **kwargs):
         """
         Why do we need to override before_import_row() ?

--- a/src/backers/admin.py
+++ b/src/backers/admin.py
@@ -8,13 +8,13 @@ from django.db.models import Count, Q
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
-from import_export import resources
-from import_export.admin import ImportMixin
+from import_export.admin import ImportExportActionModelAdmin
 from import_export.formats import base_formats
 
 from core.forms import RichTextField
 from upload.settings import TRUMBOWYG_UPLOAD_ADMIN_JS
 from backers.models import BackerGroup, Backer
+from backers.resources import BackerResource
 from categories.models import Category
 from programs.models import Program
 
@@ -58,17 +58,6 @@ class LogoFilter(admin.SimpleListFilter):
         return queryset
 
 
-class BackerResource(resources.ModelResource):
-    """Resource for Import-export."""
-
-    class Meta:
-        model = Backer
-        skip_unchanged = True
-        # name must be unique
-        import_id_fields = ('name',)
-        fields = ('name',)
-
-
 class BackerForm(forms.ModelForm):
     description = RichTextField(label=_('Description'), required=False)
 
@@ -77,7 +66,7 @@ class BackerForm(forms.ModelForm):
         fields = '__all__'
 
 
-class BackerAdmin(ImportMixin, admin.ModelAdmin):
+class BackerAdmin(ImportExportActionModelAdmin):
     """Admin module for aid backers."""
 
     resource_class = BackerResource
@@ -93,7 +82,8 @@ class BackerAdmin(ImportMixin, admin.ModelAdmin):
     ordering = ['name']
     prepopulated_fields = {'slug': ('name',)}
     readonly_fields = ['date_created', 'display_related_aids',
-                       'display_related_themes', 'display_related_programs']
+                       'display_related_themes', 'display_related_programs',
+                       'nb_financed_aids', 'nb_instructed_aids']
 
     fieldsets = [
         ('', {
@@ -106,6 +96,8 @@ class BackerAdmin(ImportMixin, admin.ModelAdmin):
                 'is_corporate',
                 'is_spotlighted',
                 'date_created',
+                'nb_financed_aids',
+                'nb_instructed_aids',
                 'display_related_aids',
                 'display_related_themes',
                 'display_related_programs'

--- a/src/backers/resources.py
+++ b/src/backers/resources.py
@@ -1,0 +1,44 @@
+
+from import_export import fields, resources
+from import_export.fields import Field
+from import_export.widgets import ForeignKeyWidget
+
+from backers.models import BackerGroup, Backer
+
+
+BACKER_IMPORT_FIELDS = ('name',)
+BACKER_EXPORT_FIELDS = (
+    'id', 'name', 'slug', 'group',
+    'nb_financed_aids', 'nb_instructed_aids',)
+
+
+class BackerResource(resources.ModelResource):
+    """Resource for Import-export."""
+
+    group = fields.Field(
+        column_name='group',
+        attribute='group',
+        widget=ForeignKeyWidget(BackerGroup, field='name')
+    )
+    nb_financed_aids = Field(column_name="nb_financed_aids")
+    nb_instructed_aids = Field(column_name="nb_instructed_aids")
+
+    def dehydrate_nb_financed_aids(self, obj):
+        return obj.nb_financed_aids
+
+    def dehydrate_nb_instructed_aids(self, obj):
+        return obj.nb_instructed_aids
+
+    class Meta:
+        model = Backer
+        skip_unchanged = True
+        # name must be unique
+        import_id_fields = ('name',)
+        fields = BACKER_EXPORT_FIELDS
+        export_order = BACKER_EXPORT_FIELDS
+
+    def get_import_fields(self):
+        return [field for field in self.get_fields() if field.column_name in BACKER_IMPORT_FIELDS]  # noqa
+
+    def get_user_visible_fields(self):
+        return [field for field in self.get_fields() if field.column_name in BACKER_IMPORT_FIELDS]  # noqa


### PR DESCRIPTION
Rend possible l'export de l'ensemble des porteurs au format cvs/xlsx depuis l'admin avec les champs non présents dans le model.