### PR TITLE
Permet de mettre uniquement un taux de subvention min dans le formulaire d'aide

### DIFF
--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -138,9 +138,6 @@ class BaseAidForm(forms.ModelForm):
                 msg = _('Please provide a financer, or suggest a new one.')
                 self.add_error('financers', msg)
 
-        if 'subvention_rate' in data and data['subvention_rate']:
-            lower = data['subvention_rate'].lower
-            upper = data['subvention_rate'].upper
         return data
 
     def save(self, commit=True):

--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -141,11 +141,6 @@ class BaseAidForm(forms.ModelForm):
         if 'subvention_rate' in data and data['subvention_rate']:
             lower = data['subvention_rate'].lower
             upper = data['subvention_rate'].upper
-            if lower and not upper:
-                msg = _('Please indicate the maximum subvention rate.')
-                self.add_error(
-                    'subvention_rate',
-                    ValidationError(msg, code='missing_upper_bound'))
         return data
 
     def save(self, commit=True):

--- a/src/aids/tests/test_forms.py
+++ b/src/aids/tests/test_forms.py
@@ -330,12 +330,11 @@ def test_aid_edition_subvention_rate_validation(aid_form_data):
     form = AidEditForm(aid_form_data)
     assert form.is_valid()
 
-    # Upper range is mandatory
+    # Upper range is optional
     aid_form_data['subvention_rate_0'] = 40
     aid_form_data['subvention_rate_1'] = None
     form = AidEditForm(aid_form_data)
-    assert not form.is_valid()
-    assert form.has_error('subvention_rate', 'missing_upper_bound')
+    assert form.is_valid()
 
     # Range must be in the correct order
     aid_form_data['subvention_rate_0'] = 50

--- a/src/core/fields.py
+++ b/src/core/fields.py
@@ -32,7 +32,6 @@ class RangeMaxValueOrNoneValidator(validators.RangeMaxValueValidator):
 
     def compare(self, a, b):
         return a.upper is not None and a.upper > b
-        message = _('Ensure that this range is completely less than or equal to %(limit_value)s.')
 
 
 class PercentRangeField(IntegerRangeField):

--- a/src/core/fields.py
+++ b/src/core/fields.py
@@ -27,9 +27,17 @@ class RangeMinValueOrNoneValidator(validators.RangeMinValueValidator):
         return a.lower is not None and a.lower < b
 
 
+class RangeMaxValueOrNoneValidator(validators.RangeMaxValueValidator):
+    """Make sure the upper range is < some value *if* it is provided."""
+
+    def compare(self, a, b):
+        return a.upper is not None and a.upper > b
+        message = _('Ensure that this range is completely less than or equal to %(limit_value)s.')
+
+
 class PercentRangeField(IntegerRangeField):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.validators.append(RangeMinValueOrNoneValidator(0))
-        self.validators.append(validators.RangeMaxValueValidator(100))
+        self.validators.append(RangeMaxValueOrNoneValidator(100))


### PR DESCRIPTION
https://trello.com/c/0cdcm6il/1043-taux-min-de-subvention-non-obligatoire