### PR TITLE
Ouverture des liens ajoutés depuis l'admin dans un nouvel onglet

### DIFF
--- a/src/dataproviders/utils.py
+++ b/src/dataproviders/utils.py
@@ -34,7 +34,8 @@ def content_prettify(raw_text, more_allowed_tags=[], more_allowed_attrs=[]):
     unquoted = unescaped \
         .replace('“', '"') \
         .replace('”', '"') \
-        .replace('’', "'")
+        .replace('’', "'") \
+        .replace('target="_blank"', 'target="_blank" rel="noopener"')
     normalized = normalize('NFKC', unquoted)
 
     # Cleaning html markup

--- a/src/static/js/shared_config.js
+++ b/src/static/js/shared_config.js
@@ -26,5 +26,6 @@ var trumbowygConfig = {
             serverPath: '/upload/',
             fileFieldName: 'image'
         }
-    }
+    },
+    defaultLinkTarget: '_blank',
 }


### PR DESCRIPTION
On force le comportement par défaut des liens quand ils sont ajoutés depuis l'admin : Tous les liens ajoutés depuis l'éditeur de texte s'ouvriront par défaut dans un nouvel onglet.