### PR TITLE
Avoir les détails de la recherche dans AidDetailView (pour les alertes)

### DIFF
--- a/src/aids/templatetags/aids.py
+++ b/src/aids/templatetags/aids.py
@@ -8,6 +8,9 @@ from django.utils.safestring import mark_safe
 from django.utils.html import format_html
 from django.conf import settings
 
+from aids.models import Aid
+
+
 register = template.Library()
 
 
@@ -27,7 +30,7 @@ def choices_display(obj, field):
 
 @register.simple_tag
 def grouped_choices_display(obj, field):
-    """Correct rendering of `ChoiceArrayField` values.."""
+    """Correct rendering of grouped `ChoiceArrayField` values.."""
 
     choices = obj._meta.get_field(field).base_field.choices
     flat_values = []
@@ -36,8 +39,32 @@ def grouped_choices_display(obj, field):
     choices_dict = dict(flat_values)
 
     keys = set(getattr(obj, field))
+
     values = [force_str(choices_dict[key]) for key in keys]
     return ', '.join(values)
+
+
+@register.simple_tag
+def form_choices_display(obj, field):
+    """Correct rendering of `MultipleChoiceField` values.."""
+
+    choices_dict = dict()
+
+    if field == 'targeted_audiences':
+        choices_dict = dict(Aid.AUDIENCES)
+    elif field in ['aid_type', 'aid_types']:
+        choices_dict = dict(Aid.TYPES)
+    elif field in ['mobilization_step', 'mobilization_steps']:
+        choices_dict = dict(Aid.STEPS)
+    elif field == 'destinations':
+        choices_dict = dict(Aid.DESTINATIONS)
+    # recurrence ? ChoiceField
+
+    # set to empty list if None
+    keys = obj.get(field, [])
+
+    values = [force_str(choices_dict.get(key, '')) for key in keys]
+    return ', '.join(filter(None, values))
 
 
 @register.simple_tag(takes_context=True)

--- a/src/search/tests/test_utils.py
+++ b/src/search/tests/test_utils.py
@@ -48,6 +48,19 @@ def test_clean_search_querystring(input_querystring, expected_cleaned_querystrin
 
 
 querystring_testset = [
+    ('', ''),  # expecting nothing
+    ('drafts=True&call_for_projects_only=False', 'drafts=True'),  # noqa
+    ('text=&order_by=relevance&perimeter=', ''),
+]
+
+
+@pytest.mark.parametrize('input_querystring,expected_cleaned_querystring', querystring_testset)  # noqa
+def test_clean_search_querystring_with_remove_extra_fields(input_querystring, expected_cleaned_querystring):  # noqa
+
+    assert clean_search_querystring(input_querystring, remove_extra_fields=True) == expected_cleaned_querystring  # noqa
+
+
+querystring_testset = [
     ('', 'draft', None),
     ('draft=', 'draft', ''),
     ('internal=True', 'internal', 'True'),

--- a/src/templates/aids/_search_meta.html
+++ b/src/templates/aids/_search_meta.html
@@ -1,75 +1,81 @@
-{% load i18n %}
+{% load i18n aids %}
 
 <div class="search-meta">
 
     {% if display == "all" %}
+        {% if not current_search_dict %}
+            <i>Vous n'avez pas séléctionné de filtres. Obtenez des aides plus personnalisées en sélectionnant des critères lors de votre recherche.</i>
+        {% endif %}
+    {% endif %}
+
+    {% if display == "all" %}
         {% block search-meta-targeted-audiences %}
-        {% if targeted_audiences %}
+        {% if current_search_dict.targeted_audiences %}
             <p title="{{ _('Targeted audiences') }}">
                 <span class="fas fa-building fa-fw"></span>
-                {{ targeted_audiences|join:', ' }}
+                {% form_choices_display current_search_dict 'targeted_audiences' %}
             </p>
         {% endif %}
         {% endblock %}
     {% endif %}
 
     {% block search-meta-perimeter %}
-    {% if perimeter %}
+    {% if current_search_dict.perimeter %}
         <p title="{{ _('Perimeter') }}">
             <span class="fas fa-map-pin fa-fw"></span>
-            {{ perimeter }}
+            {{ current_search_dict.perimeter }}
         </p>
     {% endif %}
     {% endblock %}
 
     {% if display == "all" %}
         {% block search-meta-programs %}
-        {% if programs %}
+        {% if current_search_dict.programs %}
             <p title="{{ _('Aid programs') }}">
                 <span class="fas fa-scroll fa-fw"></span>
-                {{ programs|join:', ' }}
+                {{ current_search_dict.programs|join:', ' }}
             </p>
         {% endif %}
         {% endblock %}
 
         {% block search-meta-backers %}
-        {% if backers %}
+        {% if current_search_dict.backers %}
             <p title="{{ _('Aid backers') }}">
                 <span class="fas fa-handshake fa-fw"></span>
-                {{ backers|join:', ' }}
+                {{ current_search_dict.backers|join:', ' }}
             </p>
         {% endif %}
         {% endblock %}
 
         {% block search-meta-aid-type %}
-        {% if aid_type %}
+        {% if current_search_dict.aid_type %}
             <p title="{{ _('Aid type') }}">
                 <span class="fas fa-cog fa-fw"></span>
-                {{ aid_type|join:', ' }}
+                {% form_choices_display current_search_dict 'aid_type' %}
             </p>
         {% endif %}
         {% endblock %}
 
         {% block search-meta-mobilization-step %}
-        {% if mobilization_step %}
+        {% if current_search_dict.mobilization_step %}
             <p title="{{ _('Project progress') }}">
                 <span class="fas fa-hourglass fa-fw"></span>
-                {{ mobilization_step|join:', ' }}
+                {% form_choices_display current_search_dict 'mobilization_step' %}
             </p>
         {% endif %}
         {% endblock %}
 
         {% block search-meta-destinations %}
-        {% if destinations %}
+        {% if current_search_dict.destinations %}
             <p title="{{ _('Concerned actions') }}">
                 <span class="fas fa-wallet fa-fw"></span>
-                {{ destinations|join:', ' }}
+                {% form_choices_display current_search_dict 'destinations' %}
             </p>
         {% endif %}
         {% endblock %}
 
         {% block search-meta-call-for-project %}
-        {% if call_for_projects_only %}
+        {% if current_search_dict.call_for_projects_only %}
             <p title="{{ _('Call for projects only') }}">
                 <span class="fas fa-thumbtack fa-fw"></span>
                 {{ _('Call for projects only') }}
@@ -78,18 +84,18 @@
         {% endblock %}
 
         {% block search-meta-text %}
-        {% if form.text.value %}
+        {% if current_search_dict.text %}
             <p title="{{ _('Keyword') }}">
                 <span class="fas fa-quote-left fa-fw"></span>
-                {{ form.text.value }}
+                {{ current_search_dict.text }}
             </p>
         {% endif %}
         {% endblock %}
     {% endif %}
 
     {% block search-meta-categories %}
-    {% if categories %}
-    {% regroup categories by theme as theme_list %}
+    {% if current_search_dict.categories %}
+    {% regroup current_search_dict.categories by theme as theme_list %}
     <ul class="aid-categories" title="{{ _('Categories') }}">
         {% for theme in theme_list %}
             <li class="theme">
@@ -105,9 +111,9 @@
             </li>
         {% endfor %}
     </ul>
-    {% elif themes %}
+    {% elif current_search_dict.themes %}
     <ul class="aid-categories" title="{{ _('Themes') }}">
-        {% for theme in themes %}
+        {% for theme in current_search_dict.themes %}
             <li class="theme">
                 {% if forloop.first %}
                     <span class="fas fa-tags fa-fw"></span>

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -425,7 +425,7 @@
     });
 </script>
 <script>
-    AID_SLUG = '{{ aid_slug }}';
+    AID_SLUG = '{{ aid.slug }}';
     CURRENT_SEARCH = '{{ current_search | safe }}';
 </script>
 {% compress js %}

--- a/src/templates/alerts/_alert_modal.html
+++ b/src/templates/alerts/_alert_modal.html
@@ -12,12 +12,10 @@
                 </header>
 
                 <div class="content">
-                    {% if form %}
-                        <div class="info">
-                            <h5>{{ _('Selected filters') }}</h5>
-                            {% include 'aids/_search_meta.html' with display="all" %}
-                        </div>
-                    {% endif %}
+                    <div class="info">
+                        <h5>{{ _('Selected filters') }}</h5>
+                        {% include 'aids/_search_meta.html' with display="all" %}
+                    </div>
 
                     {% csrf_token %}
                     {% include '_field_snippet.html' with field=alert_form.email %}


### PR DESCRIPTION
Faire en sorte de récupérer les détails de la recherche sur d'autres pages que la recherche, pour pouvoir : 
- avoir ces filtres au moment de la création de l'alerte sous une fiche aide
- futurs usage (noter la pertinence d'une aide par rapport à la recherche / le projet choisi)
- afficher un message si il n'y a aucun filtre séléctionné

Où ca coincait : 
- impossible de sérialiser (pour stocker dans la session) le dict AidSearchForm
- la querystring plate contient des slugs, des ids ou des mots en anglais, pas pratique pour afficher ces infos dans l'interface, du coup il nous faut repasser par le formulaire pour cleaner la donnée