### PR TITLE
Bug Scalingo : Au redémarrage, on perd les "static assets"

### DIFF
--- a/src/scripts/post_deploy.sh
+++ b/src/scripts/post_deploy.sh
@@ -7,5 +7,4 @@
 
 echo "Entering post deploy hook"
 python manage.py migrate
-python manage.py compress --force
 echo "Completed post deploy hook"

--- a/src/scripts/start.sh
+++ b/src/scripts/start.sh
@@ -12,5 +12,7 @@ if [ -z "$WSGI_MODULE" ]
 fi
 echo "Using WSGI module: $WSGI_MODULE"
 python manage.py compilemessages
+python manage.py collectstatic --noinput
+python manage.py compress --force
 gunicorn $WSGI_MODULE --log-file -
 echo "Completed deployment start script"


### PR DESCRIPTION
C'est un problème avec la persistance des fichiers sur les containers Scalingo. Il faut régénérer les fichiers "static" au moment de chaque redémarrage.