### PR TITLE
Affiche les liens externes dans les imports

### DIFF
--- a/src/aids/models.py
+++ b/src/aids/models.py
@@ -725,4 +725,6 @@ class Aid(xwf_models.WorkflowEnabled, models.Model):
         return self.local_aids.exists()
 
     def is_corporate_aid(self):
-        return 'private_sector' in self.targeted_audiences
+        return (
+            self.targeted_audiences and
+            'private_sector' in self.targeted_audiences)

--- a/src/dataproviders/scrapers/grand_est.py
+++ b/src/dataproviders/scrapers/grand_est.py
@@ -66,10 +66,11 @@ class GrandEstSpider(scrapy.Spider):
 
         yield {
             'title': content_prettify(title),
-            'description': content_prettify(description),
+            'description': content_prettify(
+                description, base_url=self.BASE_URL),
             'current_url': current_url,
             'uniqueid': unique_id,
-            'contact': content_prettify(contact),
+            'contact': content_prettify(contact, base_url=self.BASE_URL),
             'category': response.meta['category'],
             'is_call_for_project': response.meta['is_call_for_project'],
             'submission_deadline': response.meta['submission_deadline'],

--- a/src/dataproviders/scrapers/occitanie.py
+++ b/src/dataproviders/scrapers/occitanie.py
@@ -5,14 +5,14 @@ from dataproviders.utils import content_prettify
 from bs4 import BeautifulSoup as bs
 
 
-def custom_prettify(raw_text):
+def custom_prettify(raw_text, base_url=None):
     """Prettify content and performs some specific cleaning tasks."""
     soup = bs(raw_text, features='html.parser')
     download_box = soup.select('div.boite_telechargements_libre')
     for box in download_box:
         box.decompose()
 
-    return content_prettify(soup.prettify())
+    return content_prettify(soup.prettify(), base_url=base_url)
 
 
 class OccitanieSpider(scrapy.Spider):
@@ -43,7 +43,8 @@ class OccitanieSpider(scrapy.Spider):
 
         yield {
             'title': content_prettify(title),
-            'description': custom_prettify(description),
+            'description': custom_prettify(
+                description, base_url=self.BASE_URL),
             'url': fields['url'],
             'uniqueid': response.meta['uniqueid'],
             'thematique': fields.get('thematique', None),

--- a/src/dataproviders/scrapers/rmc.py
+++ b/src/dataproviders/scrapers/rmc.py
@@ -26,7 +26,8 @@ class RMCSpider(scrapy.Spider):
 
         yield {
             'title': title,
-            'description': content_prettify(description),
+            'description': content_prettify(
+                description, base_url=self.BASE_URL),
             'current_url': current_url,
             'uniqueid': unique_id,
         }

--- a/src/dataproviders/tests/test_utils.py
+++ b/src/dataproviders/tests/test_utils.py
@@ -1,0 +1,27 @@
+from dataproviders.utils import content_prettify
+
+
+def test_prettify_creates_absolute_urls():
+
+    # Relative urls are made absolute
+    html = '''
+    This is a <a href="/toto.html">long text with a link</a>
+    '''
+    text = content_prettify(html, base_url='https://www.example.org')
+    assert '<a href="https://www.example.org/toto.html">' in text
+
+    # Absolute urls are left untouched
+    html = '''
+    This is a <a href="https://www.example.org/toto.html">long text
+    with a link</a>
+    '''
+    text = content_prettify(html, base_url='https://www.example.org')
+    assert '<a href="https://www.example.org/toto.html">' in text
+
+    # Urls for other domains are left untouched
+    html = '''
+    This is a <a href="https://www.example.com/toto.html">long text
+    with a link</a>
+    '''
+    text = content_prettify(html, base_url='https://www.example.org')
+    assert '<a href="https://www.example.com/toto.html">' in text

--- a/src/dataproviders/utils.py
+++ b/src/dataproviders/utils.py
@@ -1,17 +1,21 @@
 from html import unescape
 from unicodedata import normalize
 from bs4 import BeautifulSoup as bs
+from urllib.parse import urljoin
 
 REMOVABLE_TAGS = ['script', 'style']
 ALLOWED_TAGS = [
     'p', 'ul', 'ol', 'li', 'strong', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-    'br',
+    'br', 'a'
 ]
 ALLOWED_ATTRS = ['href', 'src', 'alt', 'width', 'height', 'style',
                  'target', 'rel']  # for links opening in a new tab
 
 
-def content_prettify(raw_text, more_allowed_tags=[], more_allowed_attrs=[]):
+def content_prettify(raw_text,
+                     more_allowed_tags=[],
+                     more_allowed_attrs=[],
+                     base_url=None):
     """Clean imported data.
 
     We import data from many data sources, and it's not always directly
@@ -24,6 +28,7 @@ def content_prettify(raw_text, more_allowed_tags=[], more_allowed_attrs=[]):
      * removes all `script` html tags
      * removes most of html tags (but leave their content)
      * removes all html tag attributes
+     * replaces relative urls with absolute ones
      * autoindent existing html
 
     """
@@ -63,6 +68,10 @@ def content_prettify(raw_text, more_allowed_tags=[], more_allowed_attrs=[]):
                 # Remove tags with empty strings (or newlines, etc.)
                 elif tag.string and not tag.string.strip():
                     tag.decompose()
+
+                # Replace relative urls with absolute ones
+                if tag.name == 'a' and base_url:
+                    tag['href'] = urljoin(base_url, tag['href'])
 
             # Some tags are not allowed, but we do not want to remove
             # their content.


### PR DESCRIPTION
Dans le nettoyage des données importées, accepte les balises « a ».

Pour éviter de casser les liens, transforme les urls relatives en urls absolues.