### PR TITLE
Masquer la liste des thématiques sur la fiche aides si > 4

### DIFF
--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -1127,9 +1127,10 @@ article#aid {
     }
 
     a#collapse-categories-btn {
-        @extend .btn;
-        @extend .btn-primary;
-        @extend .mt-3;
+        display: inline-block;
+        color: $dark-green !important;
+        font-weight: 900;
+        @extend .mt-1;
 
         &[aria-expanded="true"] {
             display: none;

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -1173,7 +1173,7 @@ article#aid {
 
     .aid-content {
         @extend .row;
-        @extend .mt-5;
+        @extend .mt-4;
 
         overflow-wrap: break-word;
         word-wrap: break-word;

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -1126,6 +1126,16 @@ article#aid {
         }
     }
 
+    a#collapse-categories-btn {
+        @extend .btn;
+        @extend .btn-primary;
+        @extend .mt-3;
+
+        &[aria-expanded="true"] {
+            display: none;
+        }
+    }
+
     div.deadline-data {
         float: right;
         @extend .ml-3;

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -45,9 +45,9 @@
     {% if aid.categories %}
     {% regroup aid.categories.all by theme as theme_list %}
     <ul class="aid-categories">
-        {% if theme_list|length > 3 %}
+        {% if theme_list|length > 4 %}
             {% for theme in theme_list %}
-                {% if forloop.counter < 4 %}
+                {% if forloop.counter < 5 %}
                 <li class="theme">
                     <strong>
                         {{ theme.grouper }}

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -45,48 +45,24 @@
     {% if aid.categories %}
     {% regroup aid.categories.all by theme as theme_list %}
     <ul class="aid-categories">
-        {% if theme_list|length > 4 %}
-            {% for theme in theme_list %}
-                {% if forloop.counter < 5 %}
-                <li class="theme">
-                    <strong>
-                        {{ theme.grouper }}
-                    </strong>
-                    <ul>
-                        {% for category in theme.list %}
-                        <li class="category">{{ category }}</li>
-                        {% endfor %}
-                    </ul>
-                </li>
-                {% else %}
-                <div class="collapse hidden-categories">
-                    <li class="theme">
-                        <strong>
-                            {{ theme.grouper }}
-                        </strong>
-                        <ul>
-                            {% for category in theme.list %}
-                            <li class="category">{{ category }}</li>
-                            {% endfor %}
-                        </ul>
-                    </li>
-                </div>
-                {% endif %}
-            {% endfor %}
-            <a href=".hidden-categories" data-toggle="collapse" id="collapse-categories-btn">Afficher toutes les thématiques</a>
+        {% for theme in theme_list %}
+        {% if forloop.counter < 5 %}
+        <li class="theme">
         {% else %}
-            {% for theme in theme_list %}
-            <li class="theme">
-                <strong>
-                    {{ theme.grouper }}
-                </strong>
-                <ul>
-                    {% for category in theme.list %}
-                    <li class="category">{{ category }}</li>
-                    {% endfor %}
-                </ul>
-            </li>
-            {% endfor %}
+        <li class=" theme collapse hidden-categories">
+        {% endif %}
+            <strong>
+                {{ theme.grouper }}
+            </strong>
+            <ul>
+                {% for category in theme.list %}
+                <li class="category">{{ category }}</li>
+                {% endfor %}
+            </ul>
+        </li>
+        {% endfor %}
+        {% if theme_list|length > 4%}
+        <a href=".hidden-categories" data-toggle="collapse" id="collapse-categories-btn">Afficher toutes les thématiques</a>
         {% endif %}
     </ul>
     {% endif %}

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -46,10 +46,10 @@
     {% regroup aid.categories.all by theme as theme_list %}
     <ul class="aid-categories">
         {% for theme in theme_list %}
-        {% if forloop.counter < 5 %}
+        {% if forloop.counter <= 4 %}
         <li class="theme">
         {% else %}
-        <li class=" theme collapse hidden-categories">
+        <li class="theme collapse hidden-categories">
         {% endif %}
             <strong>
                 {{ theme.grouper }}

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -45,18 +45,49 @@
     {% if aid.categories %}
     {% regroup aid.categories.all by theme as theme_list %}
     <ul class="aid-categories">
-        {% for theme in theme_list %}
-        <li class="theme">
-            <strong>
-                {{ theme.grouper }}
-            </strong>
-            <ul>
-                {% for category in theme.list %}
-                <li class="category">{{ category }}</li>
-                {% endfor %}
-            </ul>
-        </li>
-        {% endfor %}
+        {% if theme_list|length > 3 %}
+            {% for theme in theme_list %}
+                {% if forloop.counter < 4 %}
+                <li class="theme">
+                    <strong>
+                        {{ theme.grouper }}
+                    </strong>
+                    <ul>
+                        {% for category in theme.list %}
+                        <li class="category">{{ category }}</li>
+                        {% endfor %}
+                    </ul>
+                </li>
+                {% else %}
+                <div class="collapse hidden-categories">
+                    <li class="theme">
+                        <strong>
+                            {{ theme.grouper }}
+                        </strong>
+                        <ul>
+                            {% for category in theme.list %}
+                            <li class="category">{{ category }}</li>
+                            {% endfor %}
+                        </ul>
+                    </li>
+                </div>
+                {% endif %}
+            {% endfor %}
+            <a href=".hidden-categories" data-toggle="collapse" id="collapse-categories-btn">Afficher toutes les thématiques</a>
+        {% else %}
+            {% for theme in theme_list %}
+            <li class="theme">
+                <strong>
+                    {{ theme.grouper }}
+                </strong>
+                <ul>
+                    {% for category in theme.list %}
+                    <li class="category">{{ category }}</li>
+                    {% endfor %}
+                </ul>
+            </li>
+            {% endfor %}
+        {% endif %}
     </ul>
     {% endif %}
 

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -61,7 +61,7 @@
             </ul>
         </li>
         {% endfor %}
-        {% if theme_list|length > 4%}
+        {% if theme_list|length > 4 %}
         <a href=".hidden-categories" data-toggle="collapse" id="collapse-categories-btn">Afficher toutes les thématiques</a>
         {% endif %}
     </ul>


### PR DESCRIPTION
https://trello.com/c/m7Vooixt/1102-masquer-la-liste-des-ss-th%C3%A9matiques-sur-la-fiche-aide

S'il y a plus de 4 thématiques liées à la fiche aide alors on affiche seulement les 4 premières ainsi qu'un bouton permettant d'afficher les suivantes.