### PR TITLE
Admin : pouvoir chercher les Aides & Périmètres par id

### DIFF
--- a/src/aids/admin.py
+++ b/src/aids/admin.py
@@ -183,7 +183,7 @@ class BaseAidAdmin(ImportMixin, ExportActionMixin, admin.ModelAdmin):
     list_display_links = ['name']
     autocomplete_fields = ['author', 'financers', 'instructors', 'perimeter',
                            'programs']
-    search_fields = ['name']
+    search_fields = ['id', 'name']
     list_filter = [
         'status', GenericAidListFilter, 'recurrence',
         'is_imported', 'import_data_source',

--- a/src/backers/admin.py
+++ b/src/backers/admin.py
@@ -21,7 +21,7 @@ from programs.models import Program
 
 class BackerGroupAdmin(admin.ModelAdmin):
     list_display = ['name', 'slug', 'nb_backers', 'date_created']
-    search_fields = ['name']
+    search_fields = ['id', 'name']
     ordering = ['name']
     prepopulated_fields = {'slug': ('name',)}
     readonly_fields = ['date_created']

--- a/src/backers/models.py
+++ b/src/backers/models.py
@@ -172,10 +172,10 @@ class Backer(models.Model):
 
     @property
     def id_slug(self):
-        return '{}-{}'.format(self.pk, self.slug)
+        return '{}-{}'.format(self.id, self.slug)
 
     def get_absolute_url(self):
-        url_args = [self.pk]
+        url_args = [self.id]
         if self.slug:
             url_args.append(self.slug)
         return reverse('backer_detail_view', args=url_args)

--- a/src/geofr/admin.py
+++ b/src/geofr/admin.py
@@ -15,15 +15,15 @@ class PerimeterAdminForm(forms.ModelForm):
 class PerimeterAdmin(admin.ModelAdmin):
     """Admin module for perimeters."""
 
+    form = PerimeterAdminForm
     list_display = ('scale', 'name', 'manually_created', 'is_visible_to_users',
                     'code', 'is_overseas',
                     'regions', 'departments', 'epci', 'zipcodes', 'basin')
-    search_fields = ['name', 'code']
     list_filter = ('scale', 'is_overseas', 'manually_created',
                    'is_visible_to_users')
+    search_fields = ['id', 'name', 'code']
     ordering = ('-scale', 'name')
-    form = PerimeterAdminForm
-    # readonly_fields managed below
+    # readonly_fields ? managed below
 
     class Media:
         css = {


### PR DESCRIPTION
Quick fix pour se simplifier la vie quand on a seulement connaissance de l'id du Perimeter.
J'ai fait de même pour Aid & Backer. 