### PR TITLE
Détecter les recherches effectuées à partir d'une url d'alerte

### DIFF
--- a/src/alerts/models.py
+++ b/src/alerts/models.py
@@ -76,11 +76,11 @@ class Alert(models.Model):
 
     def get_absolute_url(self):
         # When accessing the alert URL, we want to keep only
-        # things that were published after the last alert
-        # was sent.
+        # things that were published after the last alert was sent.
         querydict = QueryDict(self.querystring).copy()
         published_after = self.latest_alert_date.strftime('%Y-%m-%d')
         querydict['published_after'] = published_after
+        querydict['action'] = 'alert'
         return '{}?{}'.format(reverse('search_view'), querydict.urlencode())
 
     def get_new_aids(self):

--- a/src/alerts/tests/test_alert_command.py
+++ b/src/alerts/tests/test_alert_command.py
@@ -62,3 +62,7 @@ def test_command_output_format(mailoutbox):
     # Only the first three aids are in the mail
     assert 'Schtroumpf 4' not in content
     assert 'encore d\'autres aides disponibles !' in content
+
+    # The "extra search" link should include these parameters
+    assert 'published_after=' in content
+    assert 'action=alert' in content

--- a/src/dataproviders/data/nouvelle_aquitaine_rss_categories_mapping.csv
+++ b/src/dataproviders/data/nouvelle_aquitaine_rss_categories_mapping.csv
@@ -9,7 +9,7 @@ Infrastructures,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Infrastructur
 Logement,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Logement/rss.xml,Logement et habitat,,
 Politique contractuelle,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Politique%20contractuelle/rss.xml,Appui méthodologique,,
 Politique de la ville,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Politique%20de%20la%20ville/rss.xml,Bâtiments et construction,Espaces verts,
-Santé,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Sant%C3%A9/rss.xml,Santé et soins,,
+Santé,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Sant%C3%A9/rss.xml,Santé,,
 Silver économie,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Silver%20%C3%A9conomie/rss.xml,Personnes âgées,,
 Solidarité,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Solidarit%C3%A9/rss.xml,Accès aux services,Cohésion sociale et inclusion,Lutte contre la précarité
 Sport,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Sport/rss.xml,Sports et loisirs,,
@@ -46,7 +46,7 @@ Financement,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Financement/rss.x
 Formation professionnelle,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Formation%20professionnelle/rss.xml,Formation professionnelle,,
 Innovation,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Innovation/rss.xml,"Innovation, créativité et recherche",
 Numérique,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Num%C3%A9rique/rss.xml,Technologies numériques et numérisation,Inclusion numérique,
-Pêche,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/P%C3%AAche/rss.xml,Mer,,
+Pêche,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/P%C3%AAche/rss.xml,Mers et océans,,
 Performance et compétitivité,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Performance%20et%20comp%C3%A9titivit%C3%A9/rss.xml,Industrie,,
 Photonique,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Photonique/rss.xml,Industrie,,
 Recherche,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Recherche/rss.xml,"Innovation, créativité et recherche",
@@ -73,4 +73,4 @@ Déchets,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/D%C3%A9chets/rss.xml
 Économies d'énergie,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/%C3%89conomies%20d%27%C3%A9nergie/rss.xml,Economie d'énergie et rénovation énergétique,,
 Énergies renouvelables,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/%C3%89nergies%20renouvelables/rss.xml,Economie d'énergie et rénovation énergétique,,
 Environnement,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Environnement/rss.xml,Biodiversité,,
-Littoral,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Littoral/rss.xml,Biodiversité,Mer,Milieux humides
+Littoral,https://les-aides.nouvelle-aquitaine.fr/fiches-rss/Littoral/rss.xml,Biodiversité,Mers et océans,Milieux humides

--- a/src/dataproviders/management/commands/import_pays_de_la_loire.py
+++ b/src/dataproviders/management/commands/import_pays_de_la_loire.py
@@ -143,7 +143,7 @@ class Command(BaseImportCommand):
     #     return 'https://www.paysdelaloire.fr/les-aides/' + aid_slug
 
     def extract_application_url(self, line):
-        application_url = line.get('source_lien', None)
+        application_url = line.get('source_lien', '')
         return application_url
 
     def extract_targeted_audiences(self, line):

--- a/src/templates/alerts/alert_body.txt
+++ b/src/templates/alerts/alert_body.txt
@@ -10,8 +10,9 @@ au format HTML. Il est possible que les liens ne s'affichent pas correctement.
   * Titre : {{ aid.name|safe }}{% if aid.submission_deadline %}
     Clôture : {{ aid.submission_deadline|date }}{% endif %}
     https://{{ domain }}{{ aid.get_absolute_url|safe }}
-{% endfor %}{% if nb_aids > 3 %}
+{% endfor %}
 
+{% if nb_aids > 3 %}
 Attention, il semble qu'il y ait encore d'autres aides disponibles !
 Rendez-vous sur Aides-territoires pour les découvrir.
 


### PR DESCRIPTION
Dans nos stats de recherche (AidSearchEvent), on est capable de détecter 3 'sources' (info qu'on peut extraire de la querystring) : 
- `action=search` = recherches classique
- `action=search-filter` = cartouche
- `action=search-filter-advanced` = recherche avancée

Mais il y a certaines recherches "fantôme" qui ne contiennent pas cette info. Je propose donc de rajouter `action=alert` dans les liens envoyés via les alertes. @SarahRubio on en avait discuté un peu il me semble