### PR TITLE
Tâche pour stocker le nombre d'aides disponibles

### DIFF
--- a/src/core/tasks.py
+++ b/src/core/tasks.py
@@ -1,8 +1,10 @@
-from django.core import management
 import logging
 
+from django.core import management
 
 from core.celery import app
+
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/stats/admin.py
+++ b/src/stats/admin.py
@@ -6,6 +6,7 @@ from stats.models import (AidViewEvent, AidSearchEvent, Event,
 
 class AidViewEventAdmin(admin.ModelAdmin):
     """The model is set to readonly"""
+
     list_display = ['id', 'aid', 'source', 'date_created']
     list_filter = ['source']
 
@@ -21,6 +22,7 @@ class AidViewEventAdmin(admin.ModelAdmin):
 
 class AidSearchEventAdmin(admin.ModelAdmin):
     """The model is set to readonly"""
+
     list_display = ['id', 'source', 'results_count', 'date_created']
     list_filter = ['source']
 
@@ -34,13 +36,9 @@ class AidSearchEventAdmin(admin.ModelAdmin):
         return False
 
 
-class EventAdmin(admin.ModelAdmin):
-    list_display = ['category', 'event', 'meta', 'source', 'value',
-                    'date_created']
-
-
 class AidMatchProjectEventAdmin(admin.ModelAdmin):
     """The model is set to readonly"""
+
     list_display = ['id', 'aid', 'project', 'date_created']
 
     def has_add_permission(self, request):
@@ -53,7 +51,21 @@ class AidMatchProjectEventAdmin(admin.ModelAdmin):
         return False
 
 
+class EventAdmin(admin.ModelAdmin):
+    """The model is set to (almost) readonly"""
+
+    list_display = ['category', 'event', 'meta', 'source', 'value',
+                    'date_created']
+    list_filter = ['category', 'event', 'source']
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
 admin.site.register(AidViewEvent, AidViewEventAdmin)
 admin.site.register(AidSearchEvent, AidSearchEventAdmin)
-admin.site.register(Event, EventAdmin)
 admin.site.register(AidMatchProjectEvent, AidMatchProjectEventAdmin)
+admin.site.register(Event, EventAdmin)

--- a/src/stats/tasks.py
+++ b/src/stats/tasks.py
@@ -1,0 +1,15 @@
+import logging
+
+from core.celery import app
+from stats.utils import log_event
+from aids.models import Aid
+
+
+logger = logging.getLogger(__name__)
+
+
+@app.task
+def store_aids_live_count():
+    logger.info("Starting stats 'aid live count' task")
+    aids_live_count = Aid.objects.live().count()
+    log_event('aid', 'live_count', source='aides-territoires', value=aids_live_count)  # noqa


### PR DESCRIPTION
Actuellement les bizdev (e.g. Alexia) checkent tous les mois le nombre d'aides "live" sur la plateforme. Cette valeur est ensuite stockée dans un Excel, et nos slides sont mise à jour.

L'idée est de stocker cette valeur dans notre table `Event`
- on rajoutera d'abord à la main les valeurs anciennes (cf l'excel)
- on définira un cron qui lancera cette commande (tous les lundis ? tous les 1er du mois ?)

Ca nous permettra enfin de créer facilement un graphique de l'évolution du nombre dispo sur notre page stats.