### PR TITLE
Bug PP affichage aides locales

### DIFF
--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -460,7 +460,7 @@ class BaseAidSearchForm(forms.Form):
 
         return zipcode
 
-    def filter_queryset(self, qs=None):
+    def filter_queryset(self, qs=None, apply_generic_aid_filter=True):
         """Filter querysets depending of input data."""
 
         # If no qs was passed, just start with all published aids
@@ -558,7 +558,8 @@ class BaseAidSearchForm(forms.Form):
         if origin_url:
             qs = qs.filter(origin_url=origin_url)
 
-        qs = self.generic_aid_filter(qs, perimeter)
+        if apply_generic_aid_filter:
+            qs = self.generic_aid_filter(qs)
 
         return qs
 
@@ -660,7 +661,7 @@ class BaseAidSearchForm(forms.Form):
         qs = qs.filter(perimeter__in=perimeter_qs)
         return qs
 
-    def generic_aid_filter(self, qs, search_perimeter):
+    def generic_aid_filter(self, qs):
         """
         We should never have both the generic aid and it's local version
         together on search results.
@@ -671,6 +672,7 @@ class BaseAidSearchForm(forms.Form):
         - When searching on a smaller area than the local aid's perimeter,
           then we display the local version.
         """
+        search_perimeter = self.cleaned_data.get('perimeter', None)
         # We will consider local aids for which the associated generic
         # aid is listed in the results - We should consider excluding a
         # local aid, only when it's generic aid is listed.

--- a/src/minisites/views.py
+++ b/src/minisites/views.py
@@ -129,7 +129,7 @@ class SiteHome(MinisiteMixin, NarrowedFiltersMixin, SearchView):
             .prefetch_related('financers', 'instructors')
 
         # Combine from filtering with the base queryset
-        qs = self.form.filter_queryset(qs)
+        qs = self.form.filter_queryset(qs, apply_generic_aid_filter=True)
 
         data = self.form.cleaned_data
 

--- a/src/search/models.py
+++ b/src/search/models.py
@@ -185,9 +185,12 @@ class SearchPage(models.Model):
         data = QueryDict(querystring)
         form = AidSearchForm(data)
         if all_aids:
-            qs = form.filter_queryset(Aid.objects.all()).distinct()
+            qs = form.filter_queryset(
+                qs=Aid.objects.all(),
+                apply_generic_aid_filter=False).distinct()
         else:
-            qs = form.filter_queryset().distinct()
+            qs = form.filter_queryset(
+                apply_generic_aid_filter=False).distinct()
 
         # Also exlude aids contained in the excluded_aids field
         qs = qs.exclude(id__in=self.excluded_aids.values_list('id', flat=True))


### PR DESCRIPTION
On minisites, we want to run the generic/local aid filtering
when we combine the form filter, not on the initial queryset filtering.

This is the avoid that we prematurally exclude some aid that should be
collected when the user changes the form search parameters.