### PR TITLE
Remplace "make css" par "make fullcss" dans la config scalingo

### DIFF
--- a/src/core/settings/production.py
+++ b/src/core/settings/production.py
@@ -64,6 +64,8 @@ CSRF_COOKIE_SECURE = True
 GOAL_REGISTER_ID = env.int('GOAL_REGISTER_ID')
 GOAL_FIRST_LOGIN_ID = env.int('GOAL_FIRST_LOGIN_ID')
 
+# When we generate css files we ALSO generate autoprefixer (-moz-, -wk-, -ms-)
+# In local env we only do "make css" command for performances reasons.
 SASS_PATH = 'make fullcss'
 
 EMAIL_BACKEND = env('EMAIL_BACKEND')

--- a/src/core/settings/production.py
+++ b/src/core/settings/production.py
@@ -64,7 +64,7 @@ CSRF_COOKIE_SECURE = True
 GOAL_REGISTER_ID = env.int('GOAL_REGISTER_ID')
 GOAL_FIRST_LOGIN_ID = env.int('GOAL_FIRST_LOGIN_ID')
 
-# When we generate css files we ALSO generate autoprefixer (-moz-, -wk-, -ms-)
+# When we generate css files we ALSO generate prefix (-moz-, -wk-, -ms-)
 # In local env we only do "make css" command for performances reasons.
 SASS_PATH = 'make fullcss'
 

--- a/src/core/settings/scalingo.py
+++ b/src/core/settings/scalingo.py
@@ -42,7 +42,9 @@ COMPRESS_ENABLED = env.bool('COMPRESS_ENABLED', default=True)
 
 NODE_MODULES_PATH = Path(DJANGO_ROOT, 'node_modules')
 
-SASS_PATH = 'make css'  # 'make fullcss' ?
+# When we generate css files we ALSO generate autoprefixer (-moz-, -wk-, -ms-)
+# In local env we only do "make css" command for performances reasons.
+SASS_PATH = 'make fullcss'
 
 COMPRESS_PRECOMPILERS = (
     ('text/x-scss', '{} include={} infile={{infile}} outfile={{outfile}}'.format(

--- a/src/core/settings/scalingo.py
+++ b/src/core/settings/scalingo.py
@@ -42,7 +42,7 @@ COMPRESS_ENABLED = env.bool('COMPRESS_ENABLED', default=True)
 
 NODE_MODULES_PATH = Path(DJANGO_ROOT, 'node_modules')
 
-# When we generate css files we ALSO generate autoprefixer (-moz-, -wk-, -ms-)
+# When we generate css files we ALSO generate prefix (-moz-, -wk-, -ms-)
 # In local env we only do "make css" command for performances reasons.
 SASS_PATH = 'make fullcss'
 


### PR DESCRIPTION
https://trello.com/c/2J3jp8E3/1133-make-css-vs-make-fullcss

Comme indiqué par Thibault, la commande `make fullcss` à la différence de la commande `make css`, génère les fichiers css à partir des fichiers scss ET génère les préfixes (`-moz-, -wk-, -ms-`) quand c'est nécessaire. Dans l'environnement local, cette commande est remplacée par "make css" pour des raisons de performances. 

- Ajout d'un commentaire expliquant cette commande dans les fichiers `production.py` et `scalingo.py`
- Passage à "`make fullcss`" dans le fichier `scalingo.py`

