### PR TITLE
Utilisation du mot "résultat" au singulier si un seul résultat pour la recherche

### DIFF
--- a/src/templates/aids/_base_search.html
+++ b/src/templates/aids/_base_search.html
@@ -8,7 +8,7 @@
 {% block content %}
 <h1>
     {% with paginator.count as nb_aids %}
-    <span class="result-count">{{ nb_aids }} resultat{{ nb_aids|pluralize:"s" }}</span>
+    <span class="result-count">{{ nb_aids }} résultat{{ nb_aids|pluralize:"s" }}</span>
     {% endwith %}
 </h1>
 

--- a/src/templates/aids/_base_search.html
+++ b/src/templates/aids/_base_search.html
@@ -8,11 +8,7 @@
 {% block content %}
 <h1>
     {% with paginator.count as nb_aids %}
-    {% if nb_aids < 2 %}
-    <span class="result-count">{{ nb_aids }} resultat</span>
-    {% else %}
-    <span class="result-count">{{ nb_aids }} resultats</span>
-    {% endif %}
+    <span class="result-count">{{ nb_aids }} resultat{{ nb_aids|pluralize:"s" }}</span>
     {% endwith %}
 </h1>
 

--- a/src/templates/aids/_base_search.html
+++ b/src/templates/aids/_base_search.html
@@ -6,9 +6,15 @@
 {% block sectionid %}search{% endblock %}
 
 {% block content %}
-<h1>{% blocktrans with paginator.count as nb_aids trimmed %}
-    <span class="result-count">{{ nb_aids }} results</span>
-{% endblocktrans %}</h1>
+<h1>
+    {% with paginator.count as nb_aids %}
+    {% if nb_aids < 2 %}
+    <span class="result-count">{{ nb_aids }} resultat</span>
+    {% else %}
+    <span class="result-count">{{ nb_aids }} resultats</span>
+    {% endif %}
+    {% endwith %}
+</h1>
 
 {% if request.GET.published_after %}
     <p class="warning">Les résultats affichés sur cette page correspondent uniquement aux aides publiées depuis votre précédent mail d'alerte.</p>


### PR DESCRIPTION
https://trello.com/c/VVKRiZYe/1142-utilisation-du-mot-r%C3%A9sultat-au-singulier-si-un-seul-r%C3%A9sultat