### PR TITLE
Test d'éligibilité : fix dans l'admin

### DIFF
--- a/src/locales/fr/LC_MESSAGES/django.po
+++ b/src/locales/fr/LC_MESSAGES/django.po
@@ -1324,9 +1324,6 @@ msgstr "Contact du porteur"
 msgid "Data Sources"
 msgstr "Sources de données"
 
-msgid "Number of aids"
-msgstr "Nombre d'aides'"
-
 msgid "Eligibility tests"
 msgstr "Tests d'éligibilité"
 


### PR DESCRIPTION
Admin : 
- fix la possibilité de sauvegarder un test avec les champs introduction & conclusion vide
- rajoute le nombre de résultats (nombre de tests effectués)