### PR TITLE
Tests : fix pour éviter certains warnings

### DIFF
--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -378,7 +378,7 @@ class BaseAidSearchForm(forms.Form):
         required=False,
         widget=forms.TextInput(
             attrs={'type': 'date'}))
-    published_after = forms.DateField(
+    published_after = forms.DateTimeField(
         label=_('Published after…'),
         required=False,
         widget=forms.TextInput(

--- a/src/aids/tests/test_search_engine.py
+++ b/src/aids/tests/test_search_engine.py
@@ -1,7 +1,8 @@
 """Test methods for the search engine view."""
 
 import pytest
-from datetime import timedelta
+from datetime import datetime, timedelta
+
 from django.urls import reverse
 from django.utils import timezone
 
@@ -27,8 +28,7 @@ def aids(perimeters):
         *AidFactory.create_batch(10, perimeter=perimeters['eure']),
         *AidFactory.create_batch(11, perimeter=perimeters['st-cyr']),
         *AidFactory.create_batch(12, perimeter=perimeters['adour-garonne']),
-        *AidFactory.create_batch(13,
-                                 perimeter=perimeters['rhone-mediterannee']),
+        *AidFactory.create_batch(13, perimeter=perimeters['rhone-mediterannee']),  # noqa
         *AidFactory.create_batch(14, perimeter=perimeters['fort-de-france']),
         *AidFactory.create_batch(15, perimeter=perimeters['outre-mer']),
 
@@ -440,15 +440,15 @@ def test_aids_can_be_filterd_by_published_after(client, perimeters):
     AidFactory(
         name='Aide A',
         perimeter=perimeters['europe'],
-        date_published='2020-09-03')
+        date_published=timezone.make_aware(datetime(2020, 9, 3)))
     AidFactory(
         name='Aide B',
         perimeter=perimeters['europe'],
-        date_published='2020-09-02')
+        date_published=timezone.make_aware(datetime(2020, 9, 2)))
     AidFactory(
         name='Aide C',
         perimeter=perimeters['europe'],
-        date_published='2019-01-01')
+        date_published=timezone.make_aware(datetime(2019, 1, 1)))
 
     url = reverse('search_view')
     res = client.get(url)

--- a/src/alerts/management/commands/create_alerts_from_csv_file.py
+++ b/src/alerts/management/commands/create_alerts_from_csv_file.py
@@ -1,6 +1,6 @@
 import os
 import csv
-import datetime
+from datetime import datetime
 import logging
 
 from django.db import transaction
@@ -92,7 +92,7 @@ class Command(BaseCommand):
         alert_title = options['title']
         alert_latest_alert_date = options['latest_alert_date']
         if alert_latest_alert_date:
-            alert_latest_alert_date = datetime.datetime \
+            alert_latest_alert_date = datetime \
                 .strptime(options['latest_alert_date'], '%Y-%m-%d') \
                 .replace(hour=12, minute=0)
             alert_latest_alert_date = timezone.make_aware(

--- a/src/alerts/tests/test_alert_create_command.py
+++ b/src/alerts/tests/test_alert_create_command.py
@@ -1,5 +1,5 @@
 import os
-import datetime
+from datetime import datetime
 import pytest
 
 from django.core.management import call_command
@@ -46,7 +46,7 @@ def test_command_create_alerts_with_date(mailoutbox):
         latest_alert_date=alert_latest_alert_date)
     assert Alert.objects.count() == 2
     assert Alert.objects.last().date_created.date() == timezone.now().date()
-    assert Alert.objects.last().latest_alert_date.date() == datetime.datetime.strptime(alert_latest_alert_date, '%Y-%m-%d').date()  # noqa
+    assert Alert.objects.last().latest_alert_date.date() == datetime.strptime(alert_latest_alert_date, '%Y-%m-%d').date()  # noqa
     assert len(mailoutbox) == 2
 
 

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,0 +1,5 @@
+# App: core
+
+This is the main settings app.
+
+Contains settings, base urls.py file, etc.

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,6 +1,0 @@
-"""This is the main settings app.
-
-Contains settings, base urls.py file, etc.
-"""
-
-default_app_config = 'core.apps.CoreConfig'

--- a/src/emails/__init__.py
+++ b/src/emails/__init__.py
@@ -1,3 +1,0 @@
-"""This is app contains emails tools"""
-
-default_app_config = 'emails.apps.EmailsConfig'

--- a/src/exporting/README.md
+++ b/src/exporting/README.md
@@ -1,0 +1,3 @@
+# App: exporting
+
+This app manages data export triggered asynchronously.

--- a/src/exporting/__init__.py
+++ b/src/exporting/__init__.py
@@ -1,3 +1,0 @@
-"""This app manages data export triggered asynchronously"""
-
-default_app_config = 'exporting.apps.ExportingConfig'

--- a/src/logs/README.md
+++ b/src/logs/README.md
@@ -1,0 +1,5 @@
+# App: logs
+
+This app manages activity logs: things that we want to see in Django admin and for which we want a log entry in the database.
+
+This is essentially a wrapper around the Django Activity Stream app that gives us a way to log a database entry for an arbitrary action.

--- a/src/logs/__init__.py
+++ b/src/logs/__init__.py
@@ -1,7 +1,0 @@
-"""This app manages activity logs : things that we want to see in
-Django admin and for which we want a log entry in the database.
-
-This is essentially a wrapper around the Django Activity Stream app
-that gives us a way to log a database entry for an arbitrary action.
-"""
-default_app_config = 'logs.apps.LogsConfig'

--- a/src/upload/README.md
+++ b/src/upload/README.md
@@ -1,0 +1,5 @@
+# App: upload
+
+This app manages file upload.
+
+We handle here the file that the admin person upload through the rich text editor.

--- a/src/upload/migrations/__init__.py
+++ b/src/upload/migrations/__init__.py
@@ -1,7 +1,0 @@
-"""This app manages file upload.
-
-We handle here the file that the admin person upload trought
-the rich text editor.
-"""
-
-default_app_config = 'upload.apps.UploadConfig'


### PR DESCRIPTION
Il y avait pas mal de warnings qui s'affichaient lorsqu'on lançait les tests (cf ci-dessous). Quelques modifs pour en enlever la plupart. Le reste dépendent de certains packets utilisés il semblerait.

```
../../../../../.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/actstream/signals.py:4
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/actstream/signals.py:4: RemovedInDjango40Warning: The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.
    'description', 'timestamp'])

../../../../../.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/apps/registry.py:91
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'actstream' defines default_app_config = 'actstream.apps.ActstreamConfig'. Django now detects this configuration automatically. You can remove default_app_config.
    app_config = AppConfig.create(entry)

../../../../../.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/apps/registry.py:91
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'django_celery_beat' defines default_app_config = 'django_celery_beat.apps.BeatConfig'. Django now detects this configuration automatically. You can remove default_app_config.
    app_config = AppConfig.create(entry)

../../../../../.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/apps/registry.py:91
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'core' defines default_app_config = 'core.apps.CoreConfig'. Django now detects this configuration automatically. You can remove default_app_config.
    app_config = AppConfig.create(entry)

../../../../../.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/apps/registry.py:91
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'logs' defines default_app_config = 'logs.apps.LogsConfig'. Django now detects this configuration automatically. You can remove default_app_config.
    app_config = AppConfig.create(entry)

../../../../../.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/apps/registry.py:91
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'exporting' defines default_app_config = 'exporting.apps.ExportingConfig'. Django now detects this configuration automatically. You can remove default_app_config.
    app_config = AppConfig.create(entry)

../../../../../.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/apps/registry.py:91
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'emails' defines default_app_config = 'emails.apps.EmailsConfig'. Django now detects this configuration automatically. You can remove default_app_config.
    app_config = AppConfig.create(entry)

../../../../../.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/kombu/utils/compat.py:93
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/kombu/utils/compat.py:93: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    for ep in importlib_metadata.entry_points().get(namespace, [])

accounts/tests/test_views.py::test_login_view_is_accessible_for_anonymous_users
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/compressor/signals.py:4: RemovedInDjango40Warning: The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.
    post_compress = django.dispatch.Signal(providing_args=['type', 'mode', 'context'])

accounts/tests/test_views.py: 75 warnings
aids/tests/test_api.py: 6 warnings
aids/tests/test_search_engine.py: 901 warnings
aids/tests/test_views.py: 208 warnings
alerts/tests/test_views.py: 12 warnings
analytics/tests/test_goal_tracking.py: 30 warnings
backers/tests/test_views.py: 8 warnings
minisites/tests/test_views.py: 192 warnings
search/tests/test_views.py: 80 warnings
aids/tests/test_aid_edit_form_ui.py: 38 warnings
aids/tests/test_search_engine_ui.py: 48 warnings
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/compressor/cache.py:29: RemovedInDjango40Warning: force_text() is deprecated in favor of force_str().
    return 'django_compressor.%s' % force_text(key)

accounts/tests/test_views.py::test_login_view_is_accessible_for_anonymous_users
accounts/tests/test_views.py::test_login_view_is_accessible_for_anonymous_users
aids/tests/test_search_engine.py::test_search_engine_view
analytics/tests/test_goal_tracking.py::test_no_goal_is_tracked
analytics/tests/test_goal_tracking.py::test_no_goal_is_tracked
analytics/tests/test_goal_tracking.py::test_simple_goal_tracking
analytics/tests/test_goal_tracking.py::test_simple_goal_tracking
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/compressor/filters/base.py:220: RemovedInDjango40Warning: smart_text() is deprecated in favor of smart_str().
    return smart_text(filtered)

accounts/tests/test_views.py: 20 warnings
aids/tests/test_api.py: 2 warnings
aids/tests/test_search_engine.py: 106 warnings
aids/tests/test_views.py: 40 warnings
alerts/tests/test_views.py: 4 warnings
analytics/tests/test_goal_tracking.py: 4 warnings
backers/tests/test_views.py: 2 warnings
minisites/tests/test_views.py: 16 warnings
search/tests/test_views.py: 8 warnings
aids/tests/test_aid_edit_form_ui.py: 4 warnings
aids/tests/test_search_engine_ui.py: 6 warnings
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/compressor/parser/default_htmlparser.py:77: RemovedInDjango40Warning: smart_text() is deprecated in favor of smart_str().
    return smart_text(elem['text'])

aids/tests/test_search_engine.py::test_aids_can_be_filterd_by_published_after
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1419: RuntimeWarning: DateTimeField Aid.date_published received a naive datetime (2020-09-03 00:00:00) while time zone support is active.
    RuntimeWarning)

aids/tests/test_search_engine.py::test_aids_can_be_filterd_by_published_after
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1419: RuntimeWarning: DateTimeField Aid.date_published received a naive datetime (2020-09-02 00:00:00) while time zone support is active.
    RuntimeWarning)

aids/tests/test_search_engine.py::test_aids_can_be_filterd_by_published_after
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1419: RuntimeWarning: DateTimeField Aid.date_published received a naive datetime (2019-01-01 00:00:00) while time zone support is active.
    RuntimeWarning)

aids/tests/test_search_engine.py::test_aids_can_be_filterd_by_published_after
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1361: RuntimeWarning: DateTimeField Aid.date_published received a naive datetime (2020-09-03 00:00:00) while time zone support is active.
    RuntimeWarning)

aids/tests/test_search_engine.py::test_aids_can_be_filterd_by_published_after
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1361: RuntimeWarning: DateTimeField Aid.date_published received a naive datetime (2020-09-01 00:00:00) while time zone support is active.
    RuntimeWarning)

aids/tests/test_search_engine.py::test_aids_can_be_filterd_by_published_after
  /Users/ming-li/.local/share/virtualenvs/src-sTPXRt_8/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1361: RuntimeWarning: DateTimeField Aid.date_published received a naive datetime (2020-09-04 00:00:00) while time zone support is active.
    RuntimeWarning)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```