### PR TITLE
Tâche pour stocker le nombre d'aides disponibles sur chaque PP

### DIFF
--- a/src/stats/tasks.py
+++ b/src/stats/tasks.py
@@ -3,6 +3,7 @@ import logging
 from core.celery import app
 from stats.utils import log_event
 from aids.models import Aid
+from search.models import SearchPage
 
 
 logger = logging.getLogger(__name__)
@@ -11,5 +12,10 @@ logger = logging.getLogger(__name__)
 @app.task
 def store_aids_live_count():
     logger.info("Starting stats 'aid live count' task")
+    # main website
     aids_live_count = Aid.objects.live().count()
     log_event('aid', 'live_count', source='aides-territoires', value=aids_live_count)  # noqa
+    # all PP
+    for search_page in SearchPage.objects.all():
+        search_page_aids_live_count = search_page.get_base_queryset().count()
+        log_event('aid', 'live_count', source=search_page.slug, value=search_page_aids_live_count)  # noqa


### PR DESCRIPTION
Dans la continuité de https://github.com/MTES-MCT/aides-territoires/pull/566 , amélioration de la tâche pour aussi stocker le nombre d'aide dispo pour chaque PP. La tâche est lancée tout les Lundi midi.

Cela permettra dans Metabase d'avoir : 
- le nombre d'aides disponible qui soit le plus récent possible
- pouvoir tracer une courbe avec l'évolution de ce nombre