### PR TITLE
Affichage propre des JSONField dans l'admin

### DIFF
--- a/src/core/admin.py
+++ b/src/core/admin.py
@@ -1,4 +1,7 @@
+import json
+
 from django.contrib import admin
+from django.utils.safestring import mark_safe
 
 
 class InputFilter(admin.SimpleListFilter):
@@ -19,3 +22,19 @@ class InputFilter(admin.SimpleListFilter):
             for k, v in changelist.get_filters_params().items()
             if k != self.parameter_name)
         yield all_choice
+
+
+def pretty_print_readonly_jsonfield(jsonfield_data):
+    """
+    Display a pretty readonly version of a JSONField
+    https://stackoverflow.com/a/60219265
+    """
+
+    result = ''
+
+    if jsonfield_data:
+        result = json.dumps(jsonfield_data, indent=4, ensure_ascii=False)
+        result_str = f'<pre>{result}</pre>'
+        result = mark_safe(result_str)
+
+    return result

--- a/src/stats/admin.py
+++ b/src/stats/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 
+from core.admin import pretty_print_readonly_jsonfield
 from stats.models import (AidSearchEvent,
                           AidViewEvent, AidContactClickEvent,
                           AidMatchProjectEvent, AidEligibilityTestEvent,
@@ -60,6 +61,13 @@ class AidEligibilityTestEventAdmin(admin.ModelAdmin):
     list_display = ['id', 'aid', 'eligibility_test', 'answer_success',
                     'source', 'date_created']
     list_filter = ['eligibility_test', 'source']
+    readonly_fields = ['get_pprint_answer_details']
+
+    def get_pprint_answer_details(self, obj=None):
+        if obj:
+            return pretty_print_readonly_jsonfield(obj.answer_details)
+        return ''
+    get_pprint_answer_details.short_description = 'Answer details (pretty)'
 
     def has_add_permission(self, request):
         return False


### PR DESCRIPTION
Ajout d'une méthode pour afficher de façon propre/joli les champs JSONField dans l'admin.
Visible dans Stats > AidEligibilityTestEvent
<img width="814" alt="Screenshot 2021-05-15 at 19 09 57" src="https://user-images.githubusercontent.com/7147385/118372282-2d5f6f00-b5b1-11eb-941f-c42705005f8c.png">
