### PR TITLE
Authentifier les utilisateurs de l'API avec un Token

### DIFF
--- a/src/accounts/admin.py
+++ b/src/accounts/admin.py
@@ -2,6 +2,8 @@ from django import forms
 from django.db.models import Count, Q, CharField, Value as V
 from django.db.models.functions import Concat
 from django.contrib import admin
+from django.urls import reverse
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
@@ -25,6 +27,27 @@ class AuthorFilter(InputFilter):
                         output_field=CharField())) \
                 .filter(Q(author_name__icontains=value))
             return qs
+
+
+class ApiTokenFilter(admin.SimpleListFilter):
+    """Custom admin filter to target users with API Tokens."""
+
+    title = 'Token API'
+    parameter_name = 'has_api_token'
+
+    def lookups(self, request, model_admin):
+        return (
+            ('Yes', _('Yes')),
+            ('No', _('No')),
+        )
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value == 'Yes':
+            return queryset.with_api_token()
+        elif value == 'No':
+            return queryset.filter(auth_token__isnull=True)
+        return queryset
 
 
 class UserAdminForm(forms.ModelForm):
@@ -51,10 +74,12 @@ class UserAdmin(BaseUserAdmin):
     list_editable = ['first_name', 'last_name']
     search_fields = ['email', 'first_name', 'last_name']
     ordering = ['last_name', 'email']
-    list_filter = ['is_superuser', 'is_contributor', 'is_certified',
-                   'ml_consent']
 
-    readonly_fields = ['nb_aids', 'last_login', 'date_joined']
+    list_filter = ['is_superuser', 'is_contributor', 'is_certified',
+                   ApiTokenFilter, 'ml_consent']
+
+    readonly_fields = ['nb_aids', 'api_token', 'last_login', 'date_joined']
+
     fieldsets = (
         (None, {
             'fields': (
@@ -85,6 +110,7 @@ class UserAdmin(BaseUserAdmin):
         (_('Permissions'), {
             'fields': (
                 'is_superuser',
+                'api_token'
             )
         }),
         (_('Misc.'), {
@@ -121,11 +147,21 @@ class UserAdmin(BaseUserAdmin):
     nb_aids.short_description = "Nombre d'aides"
     nb_aids.admin_order_field = 'aid_count'
 
-    def in_mailing_list(self, obj):
-        return obj.ml_consent
+    def in_mailing_list(self, user):
+        return user.ml_consent
     in_mailing_list.short_description = mark_safe(
         _('<abbr title="Newsletter subscriber">NL</abbr>'))
     in_mailing_list.boolean = True
+
+    def api_token(self, user):
+        try:
+            token = user.auth_token
+            return token.key
+        except AttributeError:
+            return format_html(
+                'Non. <a href="{obj_url}">Créer</a>',
+                obj_url=reverse('admin:authtoken_tokenproxy_changelist'))
+    api_token.short_description = "Token API"
 
     def get_changelist_form(self, request, **kwargs):
         return UserAdminForm

--- a/src/accounts/models.py
+++ b/src/accounts/models.py
@@ -6,8 +6,20 @@ from django.utils.translation import gettext_lazy as _
 from django.contrib.postgres.fields import ArrayField
 
 
+class UserQueryset(models.QuerySet):
+    """Custom queryset with additional filtering methods for users."""
+
+    def with_api_token(self):
+        """Only return users with an API Token."""
+
+        return self.filter(auth_token__isnull=False)
+
+
 class UserManager(BaseUserManager):
     """Custom manager for our custom User model."""
+
+    def get_queryset(self):
+        return UserQueryset(self.model, using=self._db)
 
     def _create_user(self, email, first_name, last_name, password,
                      **extra_fields):
@@ -35,6 +47,11 @@ class UserManager(BaseUserManager):
         extra_fields['is_superuser'] = True
         return self._create_user(email, first_name, last_name, password,
                                  **extra_fields)
+
+    def with_api_token(self):
+        """Only return users with an API Token."""
+
+        return self.get_queryset().with_api_token()
 
 
 class User(AbstractBaseUser, PermissionsMixin):

--- a/src/aids/admin.py
+++ b/src/aids/admin.py
@@ -80,7 +80,7 @@ class EligibilityTestFilter(admin.SimpleListFilter):
         if value == 'Yes':
             return queryset.has_eligibility_test()
         elif value == 'No':
-            return queryset.filter(eligibility_test__isnull=True)  # noqa
+            return queryset.filter(eligibility_test__isnull=True)
         return queryset
 
 

--- a/src/aids/api/views.py
+++ b/src/aids/api/views.py
@@ -5,7 +5,6 @@ from django.views.decorators.cache import cache_page
 from rest_framework import viewsets
 from rest_framework.exceptions import NotFound
 
-
 from aids.models import Aid
 from aids.api.serializers import (
     AidSerializer10, AidSerializer11, AidSerializer12, AidSerializerLatest)

--- a/src/core/settings/base.py
+++ b/src/core/settings/base.py
@@ -34,6 +34,7 @@ DJANGO_APPS = [
 THIRD_PARTY_APPS = [
     'compressor',
     'rest_framework',
+    'rest_framework.authtoken',
     'django_xworkflows',
     'corsheaders',
     'actstream',
@@ -198,6 +199,14 @@ TEMPLATES = [
 ]
 
 REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.TokenAuthentication'
+    ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.AllowAny',
+        # 'rest_framework.permissions.IsAuthenticated',
+    ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 50,
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.QueryParameterVersioning',

--- a/src/core/urls.py
+++ b/src/core/urls.py
@@ -21,16 +21,16 @@ router = routers.DefaultRouter()
 
 
 schema_view = get_schema_view(
-   openapi.Info(
-      title=_('Aides-Territoires API'),
-      default_version=f'v{settings.CURRENT_API_VERSION}',
-      description=_('API Aide'),
-      terms_of_service=reverse_lazy('legal_mentions'),
-      contact=openapi.Contact(email='tech@aides-territoires.beta.gouv.fr'),
-      license=openapi.License(name="« Licence Ouverte v2.0 » d'Etalab"),
-   ),
-   public=True,
-   permission_classes=[permissions.AllowAny],
+    openapi.Info(
+        title=_('Aides-Territoires API'),
+        default_version=f'v{settings.CURRENT_API_VERSION}',
+        description=_('API Aide'),
+        terms_of_service=reverse_lazy('legal_mentions'),
+        contact=openapi.Contact(email='tech@aides-territoires.beta.gouv.fr'),
+        license=openapi.License(name="« Licence Ouverte v2.0 » d'Etalab"),
+    ),
+    public=True,
+    permission_classes=[permissions.AllowAny],
 )
 
 api_patterns = [


### PR DESCRIPTION
Modifications apportées : 
- Ajout de `TokenAuthentication` dans django-rest-framework
- L'authentification permet seulement de savoir qui fait la requête, on ne bloque pas les requêtes pour l'instant (il faudrait basculer les permissions à `IsAuthenticated`)
- Dans l'admin, nouvelle "app" Token qui permet d'assigner un token à un utilisateur
- Dans l'admin coté Utilisateur, on peut filtrer par ceux qui ont un token. Et ce token est affiché en read-only dans leur infos

Reste à faire : 
- [x] créer un type de compte "non contributeurs" qui n'aient pas accès à la partie création/édition de l'aide : https://github.com/MTES-MCT/aides-territoires/pull/626
- ~avoir des stats d'usage par utilisateur de l'API~ (plus tard)