### PR TITLE
Répare l'envoi de certaines stats sur les PP

### DIFF
--- a/src/minisites/urls.py
+++ b/src/minisites/urls.py
@@ -21,10 +21,10 @@ api_patterns = [
     path('', include(router.urls)),
     path('perimeters/', include('geofr.api.urls')),
     path('backers/', include('backers.api.urls')),
+    path('stats/', include('stats.api.urls')),
 ]
 
 urlpatterns = [
-
     # We give two names to the same view, because with minisites, the search
     # form is also the home page.
     path('', SiteHome.as_view(),  name='home'),


### PR DESCRIPTION
Certaines stats sur les PP (AidContactClickEvent & AidEligibilityTestEvent) n'étaient pas envoyés en base. Erreurs 404 car l'url n'était pas présente dans le `urls.py` de l'app minisites