### PR TITLE
Bug lors de l'update des aides depuis un fichier csv si l'aide n'a pas d'auteur

### DIFF
--- a/src/aids/admin.py
+++ b/src/aids/admin.py
@@ -399,7 +399,8 @@ class BaseAidAdmin(FieldsetsInlineMixin,
         return super().get_form(request, obj, **kwargs)
 
     def author_name(self, aid):
-        return aid.author.full_name
+        if aid.author is not None:
+            return aid.author.full_name
     author_name.short_description = _('Author')
 
     def all_financers(self, aid):

--- a/src/aids/resources.py
+++ b/src/aids/resources.py
@@ -102,7 +102,10 @@ class AidResource(resources.ModelResource):
             if key in row:
                 del row[key]
         # add/set keys
-        if 'projects' not in row:
+        if 'projects' in row:
+            if not row.get('author'):
+                row['author'] = row.get('author', ADMIN_EMAIL) or ADMIN_EMAIL
+        else:
             row['author'] = row.get('author', ADMIN_EMAIL) or ADMIN_EMAIL
             row['is_imported'] = True
         if 'subvention_rate' in row:

--- a/src/aids/resources.py
+++ b/src/aids/resources.py
@@ -102,7 +102,7 @@ class AidResource(resources.ModelResource):
             if key in row:
                 del row[key]
         # add/set keys
-        if not 'projects' in row:
+        if 'projects' not in row:
             row['author'] = row.get('author', ADMIN_EMAIL) or ADMIN_EMAIL
             row['is_imported'] = True
         if 'subvention_rate' in row:

--- a/src/aids/resources.py
+++ b/src/aids/resources.py
@@ -102,10 +102,7 @@ class AidResource(resources.ModelResource):
             if key in row:
                 del row[key]
         # add/set keys
-        if 'projects' in row:
-            if not row.get('author'):
-                row['author'] = row.get('author', ADMIN_EMAIL) or ADMIN_EMAIL
-        else:
+        if not 'projects' in row:
             row['author'] = row.get('author', ADMIN_EMAIL) or ADMIN_EMAIL
             row['is_imported'] = True
         if 'subvention_rate' in row:


### PR DESCRIPTION
Lors de l'update des aides pour leur associer un projet depuis un import csv, un bug pouvait potentiellement apparaître si l'aide n'avait pas d'auteur (L'onglet aides de l'admin devenait inaccessible après l'import réalisé car le champ `author` était vide).