### PR TITLE
Distinguer dans les résultats les aides liées au projet recherché

### DIFF
--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -233,7 +233,8 @@ class SearchView(SearchMixin, FormMixin, ListView):
         context['alert_form'] = AlertForm(label_suffix='')
         context['promotions'] = self.get_promotions()
         context['aids_associated_to_the_project'] = self.get_aids_associated_to_project()  # noqa
-        context['project_choice'] = extract_id_from_string(self.request.GET.get('projects'))  # noqa
+        if self.request.GET.get('projects'):
+            context['project_choice'] = extract_id_from_string(self.request.GET.get('projects'))  # noqa
 
         return context
 

--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -4,7 +4,8 @@ from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib import messages
 from django.contrib.sites.shortcuts import get_current_site
-from django.db.models import Q, Count, Prefetch, Case, When, IntegerField
+from django.contrib.postgres.search import SearchQuery, SearchRank
+from django.db.models import Q, F, Count, Prefetch, Case, When, IntegerField
 from django.http import HttpResponse, HttpResponseRedirect, QueryDict
 from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
@@ -143,6 +144,32 @@ class SearchView(SearchMixin, FormMixin, ListView):
                 searched_perimeter = get_all_related_perimeter_ids(searched_perimeter.id)  # noqa
                 aids_associated_to_the_project = aids_associated_to_the_project \
                     .filter(perimeter__in=searched_perimeter)  # noqa
+
+            searched_audience = self.form.cleaned_data.get('targeted_audiences', None)
+            if searched_audience:
+                aids_associated_to_the_project = aids_associated_to_the_project \
+                    .filter(targeted_audiences__overlap=searched_audience)  # noqa
+
+            searched_programs = self.form.cleaned_data.get('programs', None)
+            if searched_programs:
+                aids_associated_to_the_project = aids_associated_to_the_project \
+                    .filter(programs__in=searched_programs)  # noqa
+
+            searched_text = self.form.cleaned_data.get('text', None)
+            if searched_text:
+                aids_associated_to_the_project = aids_associated_to_the_project \
+                    .filter(search_vector=searched_text) \
+                .annotate(rank=SearchRank(F('search_vector'), searched_text))
+
+            searched_backers = self.form.cleaned_data.get('backers', None)
+            if searched_backers:
+                aids_associated_to_the_project = aids_associated_to_the_project \
+                    .filter(Q(financers__in=searched_backers) | Q(instructors__in=searched_backers))  # noqa
+
+            searched_aid_type = self.form.cleaned_data.get('aid_type', None)
+            if searched_aid_type:
+                aids_associated_to_the_project = aids_associated_to_the_project \
+                    .filter(aid_types__overlap=searched_aid_type)  # noqa
 
             aids_associated_to_the_project = aids_associated_to_the_project.distinct()  # noqa
 

--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -233,6 +233,7 @@ class SearchView(SearchMixin, FormMixin, ListView):
         context['alert_form'] = AlertForm(label_suffix='')
         context['promotions'] = self.get_promotions()
         context['aids_associated_to_the_project'] = self.get_aids_associated_to_project()  # noqa
+        context['project_choice'] = extract_id_from_string(self.request.GET.get('projects'))  # noqa
 
         return context
 

--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib import messages
 from django.contrib.sites.shortcuts import get_current_site
-from django.contrib.postgres.search import SearchQuery, SearchRank
+from django.contrib.postgres.search import SearchRank
 from django.db.models import Q, F, Count, Prefetch, Case, When, IntegerField
 from django.http import HttpResponse, HttpResponseRedirect, QueryDict
 from django.template.loader import render_to_string
@@ -145,7 +145,7 @@ class SearchView(SearchMixin, FormMixin, ListView):
                 aids_associated_to_the_project = aids_associated_to_the_project \
                     .filter(perimeter__in=searched_perimeter)  # noqa
 
-            searched_audience = self.form.cleaned_data.get('targeted_audiences', None)
+            searched_audience = self.form.cleaned_data.get('targeted_audiences', None)  # noqa
             if searched_audience:
                 aids_associated_to_the_project = aids_associated_to_the_project \
                     .filter(targeted_audiences__overlap=searched_audience)  # noqa
@@ -159,7 +159,7 @@ class SearchView(SearchMixin, FormMixin, ListView):
             if searched_text:
                 aids_associated_to_the_project = aids_associated_to_the_project \
                     .filter(search_vector=searched_text) \
-                .annotate(rank=SearchRank(F('search_vector'), searched_text))
+                    .annotate(rank=SearchRank(F('search_vector'), searched_text))  # noqa
 
             searched_backers = self.form.cleaned_data.get('backers', None)
             if searched_backers:

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -429,6 +429,17 @@ section#program-list {
         border-radius: 2rem 0 1rem 1rem;
         margin-bottom: $card-columns-gap !important;
 
+        .projects {
+            padding: 1rem;
+            background-color: #59BBAB;
+            color: #fff;
+            text-align: center;
+            font-weight: bold;
+            border-radius: 2rem 0 0 0;
+            max-height: 4rem;
+            min-height: 4rem;
+        }
+
         &>div {
             @extend .card-body;
 

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -436,7 +436,7 @@ section#program-list {
             text-align: center;
             font-weight: bold;
             border-radius: 2rem 0 0 0;
-            max-height: 4rem;
+            max-height: 5rem;
             min-height: 4rem;
         }
 

--- a/src/templates/aids/_aid_result.html
+++ b/src/templates/aids/_aid_result.html
@@ -1,6 +1,16 @@
 {% load i18n aids %}
 
 <article class="aid">
+    {% if aid.projects.all  %}
+    {% for project in aid.projects.all %}
+        {% if project.id == project_choice %}
+        <div class="projects">
+            Cette aide correspond à votre projet !
+        </div>
+        {% endif %}
+        {% endfor %}  
+    {% endif %}
+
     <div>
         {% if aid.has_approaching_deadline %}
             <span class="deadline deadline-delta">J-{{ aid.days_before_deadline }}</span>

--- a/src/templates/aids/_aid_result.html
+++ b/src/templates/aids/_aid_result.html
@@ -6,6 +6,10 @@
         {% if project.id == project_choice %}
         <div class="projects">
             Cette aide correspond à votre projet !
+            <p>
+                <span class="fas fa-lightbulb fa-fw"></span>
+                {{ project }}
+            </p>
         </div>
         {% endif %}
         {% endfor %}  

--- a/src/templates/aids/_search_form.html
+++ b/src/templates/aids/_search_form.html
@@ -16,6 +16,7 @@
         {{ form.targeted_audiences.as_hidden }}
         {{ form.perimeter.as_hidden }}
         {{ form.themes.as_hidden }}
+        {{ form.projects.as_hidden }}
     {% endblock %}
 
     {% block other_actions %}


### PR DESCRIPTION
Si l'utilisateur a choisi l'entrée projet, dans les résultats proposés sont affichés les aides correspondant au projet recherché mais aussi les aides complémentaires liées aux catégories recherchées. 
Pour différencier les aides correspondant au projet recherché on peut mettre une étiquette indiquant "Cette aide correspond à votre projet !"