### PR TITLE
Autocomplétion du périmètre de recherche à partir du code postal 

### DIFF
--- a/src/geofr/api/serializers.py
+++ b/src/geofr/api/serializers.py
@@ -3,20 +3,13 @@ from rest_framework import serializers
 from geofr.models import Perimeter
 
 
-class ZipcodesRelatedField(serializers.StringRelatedField):
-
-    def to_representation(self, value):
-        return f'{value}'
-
-
 class PerimeterSerializer(serializers.ModelSerializer):
 
     id = serializers.CharField(source='id_slug')
     scale = serializers.CharField(source='get_scale_display')
     text = serializers.CharField(source='__str__')
 
-    zipcodes = ZipcodesRelatedField(
-        many=True)
+    zipcodes = serializers.ListField(child=serializers.CharField())
 
     class Meta:
         model = Perimeter

--- a/src/geofr/api/serializers.py
+++ b/src/geofr/api/serializers.py
@@ -3,12 +3,21 @@ from rest_framework import serializers
 from geofr.models import Perimeter
 
 
+class ZipcodesRelatedField(serializers.StringRelatedField):
+
+    def to_representation(self, value):
+        return f'{value}'
+
+
 class PerimeterSerializer(serializers.ModelSerializer):
 
     id = serializers.CharField(source='id_slug')
     scale = serializers.CharField(source='get_scale_display')
     text = serializers.CharField(source='__str__')
 
+    zipcodes = ZipcodesRelatedField(
+        many=True)
+
     class Meta:
         model = Perimeter
-        fields = ('id', 'name', 'scale', 'text')
+        fields = ('id', 'name', 'scale', 'zipcodes', 'text')

--- a/src/geofr/api/views.py
+++ b/src/geofr/api/views.py
@@ -1,5 +1,6 @@
 from rest_framework import viewsets
 from django.contrib.postgres.search import TrigramSimilarity
+from django.db.models import Q
 
 from geofr.models import Perimeter, remove_accents
 from geofr.api.serializers import PerimeterSerializer
@@ -22,7 +23,7 @@ class PerimeterViewSet(viewsets.ReadOnlyModelViewSet):
         if len(q) >= MIN_SEARCH_LENGTH:
             qs = qs \
                 .annotate(similarity=TrigramSimilarity('unaccented_name', q)) \
-                .filter(unaccented_name__trigram_similar=remove_accents(q)) \
+                .filter(Q(unaccented_name__trigram_similar=remove_accents(q)) | Q(zipcodes__icontains=accented_q)) \
                 .order_by('-similarity', '-scale', 'name')
 
         is_visible_to_users = self.request.query_params.get('is_visible_to_users', 'false')  # noqa

--- a/src/geofr/api/views.py
+++ b/src/geofr/api/views.py
@@ -23,7 +23,8 @@ class PerimeterViewSet(viewsets.ReadOnlyModelViewSet):
         if len(q) >= MIN_SEARCH_LENGTH:
             qs = qs \
                 .annotate(similarity=TrigramSimilarity('unaccented_name', q)) \
-                .filter(Q(unaccented_name__trigram_similar=remove_accents(q)) | Q(zipcodes__icontains=accented_q)) \
+                .filter(Q(unaccented_name__trigram_similar=remove_accents(q))
+                        | Q(zipcodes__icontains=accented_q)) \
                 .order_by('-similarity', '-scale', 'name')
 
         is_visible_to_users = self.request.query_params.get('is_visible_to_users', 'false')  # noqa


### PR DESCRIPTION
https://trello.com/c/xJeFzYOk/1249-prendre-en-compte-les-codes-postaux-dans-la-recherche-du-territoire-%C3%A0-l%C3%A9tape-de-recherche