### PR TITLE
Rend le champ "type d'aide" obligatoire dans le formulaire de demande de publication d'une aide

### DIFF
--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -316,6 +316,9 @@ class AidEditForm(BaseAidForm):
         if 'mobilization_steps' in self.fields:
             self.fields['mobilization_steps'].required = True
 
+        if 'aid_types' in self.fields:
+            self.fields['aid_types'].required = True
+
         if 'categories' in self.fields:
             self.fields['categories'].required = True
 


### PR DESCRIPTION
https://trello.com/c/MHmqXGJo/970-rendre-le-champ-type-daide-obligatoire