### PR TITLE
Mise à jour de la fonctionnalité de contrôle du nombre de filtres de recherches dans les PP

### DIFF
--- a/src/alerts/tests/test_alert_command.py
+++ b/src/alerts/tests/test_alert_command.py
@@ -54,7 +54,6 @@ def test_command_output_format(mailoutbox):
     call_command('send_alerts')
 
     content = mailoutbox[0].body
-    print(content)
     assert 'Gloubiboukmark' in content
     assert 'Schtroumpf 1' in content
     assert 'Schtroumpf 2' in content

--- a/src/search/forms.py
+++ b/src/search/forms.py
@@ -270,7 +270,7 @@ class SearchPageAdminForm(forms.ModelForm):
         search_fields = [
             'show_perimeter_field', 'show_audience_field',
             'show_categories_field', 'show_mobilization_step_field',
-            'show_aid_type_field',
+            'show_aid_type_field', 'show_backers_field',
         ]
         nb_filters = 0
         for field in search_fields:

--- a/src/search/tests/test_forms.py
+++ b/src/search/tests/test_forms.py
@@ -23,6 +23,7 @@ def test_valid_search_page_form():
         'show_categories_field': True,
         'show_mobilization_step_field': False,
         'show_aid_type_field': False,
+        'show_backers_field': False,
     })
 
     assert form.is_valid()
@@ -42,6 +43,7 @@ def test_search_form_field_customizations():
         'show_categories_field': False,
         'show_mobilization_step_field': False,
         'show_aid_type_field': False,
+        'show_backers_field': False,
     })
 
     assert form.is_valid()
@@ -61,6 +63,7 @@ def test_search_form_not_enough_filters():
         'show_categories_field': False,
         'show_mobilization_step_field': False,
         'show_aid_type_field': False,
+        'show_backers_field': False,
     })
 
     assert not form.is_valid()
@@ -81,6 +84,7 @@ def test_search_form_too_many_filters():
         'show_categories_field': True,
         'show_mobilization_step_field': True,
         'show_aid_type_field': True,
+        'show_backers_field': True,
     })
 
     assert not form.is_valid()


### PR DESCRIPTION
Ajout de 'show_backers_field' pour comptabiliser le nombre de filtres à afficher dans le cartouche des PP. 