### PR TITLE
Empêche de voir une aide qui n'appartient pas à la PP demandée

### DIFF
--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -411,6 +411,8 @@ class AidDetailView(DetailView):
     def get(self, request, *args, **kwargs):
         response = super().get(request, *args, **kwargs)
 
+        print(self.__dict__)
+
         if self.object.is_published():
             current_search = response.context_data.get('current_search', '')
             host = request.get_host()

--- a/src/minisites/tests/test_views.py
+++ b/src/minisites/tests/test_views.py
@@ -175,6 +175,40 @@ def test_audiences_filter_overriding(client, settings):
     assert '<option value="region">' not in content
 
 
+def test_minisite_can_view_aid(client, settings):
+    """Test we can view an Aid that belongs to the minisite."""
+
+    aid = AidFactory(name="Un repas sans fromage, c'est dommage")
+    AidFactory(name="Une soirée sans vin, ce n'est pas malin")
+
+    page = MinisiteFactory(
+        title='Gloubiboulga page',
+        search_querystring='text=fromage')
+    page_url = reverse('aid_detail_view', args=[aid.slug])
+    page_host = '{}.aides-territoires'.format(page.slug)
+    settings.ALLOWED_HOSTS = [page_host]
+
+    res = client.get(page_url, HTTP_HOST=page_host)
+    assert res.status_code == 200
+    assert 'fromage' in res.content.decode()
+
+
+def test_minisite_cannot_view_wrong_aid(client, settings):
+    """Test we cannot view an Aid that doesn't belong to the minisite."""
+
+    aid = AidFactory(name="Une soirée sans vin, ce n'est pas malin")
+
+    page = MinisiteFactory(
+        title='Gloubiboulga page',
+        search_querystring='text=fromage')
+    page_url = reverse('aid_detail_view', args=[aid.slug])
+    page_host = '{}.aides-territoires'.format(page.slug)
+    settings.ALLOWED_HOSTS = [page_host]
+
+    res = client.get(page_url, HTTP_HOST=page_host)
+    assert res.status_code == 404
+
+
 def test_alert_creation(client, settings, mailoutbox):
     """Anonymous can create alerts. They receive a validation email."""
 

--- a/src/minisites/views.py
+++ b/src/minisites/views.py
@@ -196,6 +196,14 @@ class SiteAid(MinisiteMixin, AidDetailView):
 
     template_name = 'minisites/aid_detail.html'
 
+    def get_queryset(self):
+        """
+        Check that the aid actually belongs to the minisite queryset.
+        Returns a 404 if not.
+        """
+
+        return self.search_page.get_base_queryset()
+
 
 class SiteAlert(MinisiteMixin, AlertCreate):
     pass


### PR DESCRIPTION
On a des stats bizarres sur des aides vues sur des PP dont elles ne faisaient pas partie...
```
// exemple
{'_state': <django.db.models.base.ModelState object at 0x7f8723cfc8d0>, 'id': 1423755, 'aid_id': 90771, 'targeted_audiences': None, 'querystring': '', 'source': 'petitesvillesdedemain', 'date_created': datetime.datetime(2021, 6, 17, 14, 50, 1, 846827, tzinfo=<UTC>)}
```