### PR TITLE
Entrée projet : bloquer l'envoi du formulaire si l'input projet est mal rempli

### DIFF
--- a/src/search/forms.py
+++ b/src/search/forms.py
@@ -227,7 +227,7 @@ class ProjectSearchForm(forms.Form):
         widget=forms.widgets.MultipleHiddenInput)
     projects = AutocompleteModelChoiceField(
         queryset=Project.objects.all(),
-        required=False)
+        required=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
https://trello.com/c/sZa6GXtD/1283-entr%C3%A9e-projet-bloquer-lenvoi-du-formulaire-si-linput-projet-est-mal-rempli