### PR TITLE
Administrateur de PP: On ne devrait pas avoir à ajouter l'utilisateur dans un groupe

### DIFF
--- a/src/admin_lite/mixins.py
+++ b/src/admin_lite/mixins.py
@@ -1,2 +1,43 @@
 class AdminLiteMixin:
     change_form_template = 'admin/admin_lite/change_form.html'
+
+
+class WithViewPermission:
+
+    def has_view_permission(self, request, obj=None):
+        """
+        Grant permission to authenticated users that are administrator of search pages.
+        """
+        if request.user.is_authenticated and request.user.is_administrator_of_search_pages:
+            return True
+        return super().has_view_permission(request, obj)
+
+
+class WithChangePermission(WithViewPermission):
+
+    def has_change_permission(self, request, obj=None):
+        """
+        Grant permission to authenticated users that are administrator of search pages.
+        """
+        if request.user.is_authenticated and request.user.is_administrator_of_search_pages:
+            return True
+        return super().has_view_permission(request, obj)
+
+
+class WithFullPermission(WithChangePermission):
+
+    def has_add_permission(self, request, obj=None):
+        """
+        Grant permission to authenticated users that are administrator of search pages.
+        """
+        if request.user.is_authenticated and request.user.is_administrator_of_search_pages:
+            return True
+        return super().has_add_permission(request, obj)
+
+    def has_delete_permission(self, request, obj=None):
+        """
+        Grant permission to authenticated users that are administrator of search pages.
+        """
+        if request.user.is_authenticated and request.user.is_administrator_of_search_pages:
+            return True
+        return super().has_delete_permission(request, obj)

--- a/src/aids/admin.py
+++ b/src/aids/admin.py
@@ -16,17 +16,18 @@ from admin_auto_filters.filters import AutocompleteFilter
 from fieldsets_with_inlines import FieldsetsInlineMixin
 from adminsortable2.admin import SortableInlineAdminMixin
 
-from aids.utils import generate_clone_title
+from accounts.admin import AuthorFilter
+from admin_lite.mixins import WithViewPermission
 from aids.admin_views import AmendmentMerge
 from aids.forms import AidAdminForm
 from aids.models import Aid, AidWorkflow, AidFinancer, AidInstructor
 from aids.resources import AidResource
+from aids.utils import generate_clone_title
 from core.admin import InputFilter, pretty_print_readonly_jsonfield
-from accounts.admin import AuthorFilter
-from search.models import SearchPage
 from exporting.tasks import export_aids_as_csv, export_aids_as_xlsx
 from exporting.utils import get_admin_export_message
 from geofr.utils import get_all_related_perimeter_ids
+from search.models import SearchPage
 from upload.settings import TRUMBOWYG_UPLOAD_ADMIN_JS
 
 
@@ -494,7 +495,7 @@ class BaseAidAdmin(FieldsetsInlineMixin,
         'Export and download selected Aids')
 
 
-class AidAdmin(BaseAidAdmin):
+class AidAdmin(WithViewPermission, BaseAidAdmin):
     def get_queryset(self, request):
         qs = Aid.objects \
             .all() \

--- a/src/search/admin.py
+++ b/src/search/admin.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy as _
 
 from fieldsets_with_inlines import FieldsetsInlineMixin
 
-from admin_lite.mixins import AdminLiteMixin
+from admin_lite.mixins import AdminLiteMixin, WithChangePermission, WithFullPermission
 from search.models import SearchPage, SearchPageLite, MinisiteTab, MinisiteTabLite
 from search.forms import SearchPageAdminForm, MinisiteTabForm, MinisiteTabFormLite
 from pages.admin import PageAdmin
@@ -20,7 +20,7 @@ class MinisiteTabInline(admin.TabularInline):
     max_num = 6
 
 
-class MinisiteTabLiteInline(MinisiteTabInline):
+class MinisiteTabLiteInline(WithFullPermission, MinisiteTabInline):
     """
     A lite version that's suitable for non superuser.
     """
@@ -188,7 +188,7 @@ class SearchPageAdmin(FieldsetsInlineMixin, admin.ModelAdmin):
         ] + TRUMBOWYG_UPLOAD_ADMIN_JS
 
 
-class SearchPageLiteAdmin(AdminLiteMixin, SearchPageAdmin):
+class SearchPageLiteAdmin(WithChangePermission, AdminLiteMixin, SearchPageAdmin):
     prepopulated_fields = {}
     fieldsets_with_inlines = LITE_FIELDSETS_SEARCH_PAGE
 


### PR DESCRIPTION
We use to check the user's group in order to grant these permissions.
With this change, the permissions to the admin pages are granted
automatically. This saves a extra configuration setp, since we don't
have to add the user to a group anymore.