### PR TITLE
API : enlève l'endpoint de détail d'un porteur d'aide

### DIFF
--- a/src/backers/api/views.py
+++ b/src/backers/api/views.py
@@ -1,7 +1,9 @@
 import operator
 from functools import reduce
-from rest_framework import viewsets
+
 from django.db.models import Q
+
+from rest_framework import viewsets, mixins
 
 from backers.models import Backer
 from backers.api.serializers import BackerSerializer
@@ -10,7 +12,7 @@ from backers.api.serializers import BackerSerializer
 MIN_SEARCH_LENGTH = 3
 
 
-class BackerViewSet(viewsets.ReadOnlyModelViewSet):
+class BackerViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     serializer_class = BackerSerializer
 
     def get_queryset(self):


### PR DESCRIPTION
On garde juste la possibilité de lister tous les porteurs