### PR TITLE
API : ajout de l'argument size sur des endpoints additionnels

### DIFF
--- a/src/aids/api/views.py
+++ b/src/aids/api/views.py
@@ -9,13 +9,13 @@ from rest_framework import viewsets, mixins
 from rest_framework.exceptions import NotFound
 from drf_yasg.utils import swagger_auto_schema
 
+from core.api.pagination import ApiPagination
 from aids.models import Aid
 from aids.constants import AUDIENCES_GROUPED, TYPES_GROUPED
 from aids.api import doc as api_doc
 from aids.api.serializers import (
     AidSerializer10, AidSerializer11, AidSerializer12, AidSerializerLatest,
     AidAudienceSerializer, AidTypeSerializer, AidStepSerializer, AidRecurrenceSerializer, AidDestinationSerializer)  # noqa
-from aids.api.pagination import AidsPagination
 from aids.forms import AidSearchForm
 from stats.utils import log_aidviewevent, log_aidsearchevent
 
@@ -50,7 +50,7 @@ class AidViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gene
     """
 
     lookup_field = 'slug'
-    pagination_class = AidsPagination
+    pagination_class = ApiPagination
 
     def get_base_queryset(self):
         """Get the base queryset of aid list.

--- a/src/backers/api/views.py
+++ b/src/backers/api/views.py
@@ -6,6 +6,7 @@ from django.db.models import Q
 from rest_framework import viewsets, mixins
 from drf_yasg.utils import swagger_auto_schema
 
+from core.api.pagination import ApiPagination
 from backers.models import Backer
 from backers.api import doc as api_doc
 from backers.api.serializers import BackerSerializer
@@ -22,6 +23,7 @@ class BackerViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     """
 
     serializer_class = BackerSerializer
+    pagination_class = ApiPagination
 
     def get_queryset(self):
         """Filter data according to search query."""

--- a/src/core/api/pagination.py
+++ b/src/core/api/pagination.py
@@ -1,7 +1,7 @@
 from rest_framework.pagination import PageNumberPagination
 
 
-class AidsPagination(PageNumberPagination):
+class ApiPagination(PageNumberPagination):
     page_size = 50
     page_size_query_param = 'size'
     max_page_size = 200

--- a/src/geofr/api/views.py
+++ b/src/geofr/api/views.py
@@ -5,6 +5,7 @@ from rest_framework import viewsets, mixins
 from drf_yasg.utils import swagger_auto_schema
 
 from core.utils import remove_accents
+from core.api.pagination import ApiPagination
 from geofr.models import Perimeter
 from geofr.api import doc as api_doc
 from geofr.api.serializers import PerimeterSerializer, PerimeterScaleSerializer
@@ -21,6 +22,7 @@ class PerimeterViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     """
 
     serializer_class = PerimeterSerializer
+    pagination_class = ApiPagination
 
     def get_queryset(self):
         """Filter data according to search query."""

--- a/src/programs/api/views.py
+++ b/src/programs/api/views.py
@@ -1,6 +1,7 @@
 from rest_framework import viewsets, mixins
 from drf_yasg.utils import swagger_auto_schema
 
+from core.api.pagination import ApiPagination
 from programs.models import Program
 from programs.api.serializers import ProgramSerializer
 
@@ -14,6 +15,7 @@ class ProgramViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
 
     serializer_class = ProgramSerializer
     queryset = Program.objects.all().order_by('id')
+    pagination_class = ApiPagination
 
     @swagger_auto_schema(tags=[Program._meta.verbose_name_plural])
     def list(self, request, *args, **kwargs):


### PR DESCRIPTION
Il y avait déjà l'argument size sur l'endpoint `/aids`.
On rajoute ce mécanisme aux endpoints `/backers`, `/perimeters` et `/programs` 