### PR TITLE
Fix temporaire : renvoyer une 404 si la page PVD/stats est appelée

### DIFF
--- a/src/minisites/views.py
+++ b/src/minisites/views.py
@@ -235,6 +235,9 @@ class SiteStats(MinisiteMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
+        if self.search_page.slug == "petitesvillesdedemain":
+            raise Http404('')
+
         # aid count
         context['nb_live_aids'] = self.search_page.get_base_queryset().count()
 

--- a/src/minisites/views.py
+++ b/src/minisites/views.py
@@ -236,7 +236,8 @@ class SiteStats(MinisiteMixin, TemplateView):
         context = super().get_context_data(**kwargs)
 
         if self.search_page.slug == "petitesvillesdedemain":
-            raise Http404('')
+            context['no_data'] = "Les statistiques ne sont pas actuellement disponibles, merci de revenir ultérieurement."
+            return context
 
         # aid count
         context['nb_live_aids'] = self.search_page.get_base_queryset().count()

--- a/src/templates/minisites/stats.html
+++ b/src/templates/minisites/stats.html
@@ -19,6 +19,11 @@
 {% endblock %}
 
 {% block content %}
+{% if no_data %}
+<section id="stats">
+    <div>{{ no_data }}</div>
+</section>
+{% else %}
 <section id="stats">
 
     <div class="stat half-width">
@@ -213,6 +218,7 @@
         </div>
     </div>
 </section>
+{% endif %}
 {% endblock %}
 
 {% block extra_css %}


### PR DESCRIPTION
La page stats de la PP Petitesvillesdedemain renvoi un Timeout qui affecte le trafic de toutes les PP. 

Ceci est potentiellement dû à un trop grand nombres d'évènements à gérer dans les requêtes SQL. 

En attendant de réparer ce problème on propose de renvoyer directement une 404 sur cette page de stats pour cette PP uniquement afin de ne pas perturber le reste du trafic. 