### PR TITLE
Renommer les différentes aides techniques pour éviter toutes confusions avec les aides financières

### DIFF
--- a/src/aids/constants.py
+++ b/src/aids/constants.py
@@ -35,15 +35,15 @@ FINANCIAL_AIDS = (
 )
 
 OTHER_AIDS = (
-    ('other', 'Autre'),
+    ('other', 'Autre aide financière'),
 )
 
 FINANCIAL_AIDS_LIST = ('grant', 'loan', 'recoverable_advance', 'other')
 
 TECHNICAL_AIDS = (
-    ('technical', 'Technique'),
-    ('financial', 'Financière'),
-    ('legal', 'Juridique / administrative'),
+    ('technical', 'Ingénierie technique'),
+    ('financial', 'Ingénierie financière'),
+    ('legal', 'Ingénierie Juridique / administrative'),
 )
 
 TECHNICAL_AIDS_LIST = ('technical', 'financial', 'legal')


### PR DESCRIPTION
Sur la page de détail des aides, les différentes aides en ingénieries n'apparaissait pas avec un nom assez univoque ce qui pouvait amener à une confusion. 

Ex: si l'aide était une aide en ingénierie financière apparaissait "financière" laissant penser que l'aide n'était pas une aide en ingénierie mais bien une aide financière. 

https://trello.com/c/FPdYd4LF/1365-175-probl%C3%A8me-daffichage-du-nom-des-aides-en-ing%C3%A9nierie
