### PR TITLE
Remplacer "mini-sites" par "portails"

### DIFF
--- a/src/templates/_header.html
+++ b/src/templates/_header.html
@@ -70,7 +70,7 @@
                         <a class="fr-nav__link" href="{% url 'home' %}" target="_self">Accueil</a>
                     </li>
                     <li class="fr-nav__item">
-                        <a class="fr-nav__link" href="/mini-sites/" target="_self">Mini-sites</a>
+                        <a class="fr-nav__link" href="/portails/" target="_self">Portails</a>
                     </li>
                     <li class="fr-nav__item">
                         <button class="fr-nav__btn" aria-expanded="false" aria-controls="menu-actualites">Actualités</button>

--- a/src/templates/home/home.html
+++ b/src/templates/home/home.html
@@ -97,7 +97,7 @@
                     <div class="fr-card fr-enlarge-link">
                         <div class="fr-card__body">
                             <h3 class="fr-card__title">
-                                <a href="/mini-sites/" class="fr-card__link" _target="_blank" rel="noopener" title="">Les pages de nos partenaires</a>
+                                <a href="/portails/" class="fr-card__link" _target="_blank" rel="noopener" title="">Les pages de nos partenaires</a>
                             </h3>
                             <p class="fr-card__desc fr-text">Découvrez tous les guichets dédiés à un périmètre géographique, une thématique, un programme.</p>
                         </div>


### PR DESCRIPTION
Le nouveau nom des pages personnalisées n'est plus "mini-sites" mais "portails"