### PR TITLE
FIx : duplication d'une aide générique en aide locale quand l'aide a été associée à un projet

### DIFF
--- a/src/aids/models.py
+++ b/src/aids/models.py
@@ -718,9 +718,12 @@ class Aid(xwf_models.WorkflowEnabled, models.Model):
         Clones the many-to-many fields for the the given source aid.
         """
         m2m_fields = self._meta.many_to_many
+        projects_field = self._meta.get_field('projects')
+
         for field in m2m_fields:
-            for item in field.value_from_object(source_aid):
-                getattr(self, field.attname).add(item)
+            if field != projects_field:
+                for item in field.value_from_object(source_aid):
+                    getattr(self, field.attname).add(item)
         self.save()
 
 

--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -602,7 +602,7 @@ class GenericToLocalAidView(ContributorAndProfileCompleteRequiredMixin,
         new_aid.save()
 
         self.new_aid = new_aid
-        msg = "Cette aide à été dupliquée"
+        msg = "Cette aide a été dupliquée"
         self.messages.success(msg)
         return super().post(request, *args, **kwargs)
 

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -491,7 +491,9 @@
                             </div>
                         {% endif %}
 
+                        {% if user.is_contributor %}
                         {% include 'aids/_generic_to_local.html' %}
+                        {% endif %}
 
                     {% endwith %}
                     {% endif %}


### PR DESCRIPTION
Deux erreurs existaient sur le sujet : 
1. L'utilisateur chercheur d'aide mais pas porteur d'aides avait la possibilité de cliquer sur le bouton "dupliquer cette aide" sur la page de détail d'une aide nationale.
2. Si une aide nationale avait été associée à un projet la duplication de l'aide en aide locale créé un bug lié au clone du champ M2M `projects`. 