### PR TITLE
Fix : accès à la page collaborators 

### DIFF
--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -239,7 +239,7 @@ class InviteCollaborator(ContributorAndProfileCompleteRequiredMixin, CreateView)
         return self.render_to_response(self.get_context_data(form=form, error_mail=error, users=users))  # noqa
 
 
-class CollaboratorsList(ListView):
+class CollaboratorsList(ContributorAndProfileCompleteRequiredMixin, ListView):
     """List of all the collaborators of an user"""
 
     template_name = 'accounts/collaborators.html'


### PR DESCRIPTION
L'accès à la page collaborators ne renvoyait pas l'utilisateur non authentifié vers la home mais créait une erreur 500. 