### PR TITLE
Fix design : champ 'Url d'origine' sur les pages détail aide

### DIFF
--- a/src/static/css/_globals.scss
+++ b/src/static/css/_globals.scss
@@ -18,6 +18,10 @@ h2, h3, h4, h5, h6 {
   font-weight: normal;
 }
 
+.fr-break-word {
+  word-break: break-all;
+}
+
 .fr-uppercase {
     text-transform: uppercase;
 }

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -348,7 +348,7 @@
                                 </h3>
                                 <p>Cette aide provient d'une source de données tierce</p>
                                 <div>
-                                    <p><strong>URL d'origine : </strong>{{ aid.import_data_url|default_if_none:_('NA') }}</p>
+                                    <p class="fr-break-word"><strong>URL d'origine : </strong>{{ aid.import_data_url|default_if_none:_('NA')}}</p>
                                     <p><strong>License de partage : </strong>{{ aid.get_import_share_licence_display|default:_('NA') }}</p>
                                     <p><strong>Dernière mise à jour : </strong>{{ aid.import_last_access|date }}<p>
                                 </div>    


### PR DESCRIPTION
https://www.notion.so/Fix-design-champ-Url-d-origine-sur-les-pages-d-tail-aide-aac3b5892ff741faae058c4e3a5910ce