### PR TITLE
Ajout des balises OG manquantes

### DIFF
--- a/src/templates/aids/_base_search.html
+++ b/src/templates/aids/_base_search.html
@@ -3,6 +3,16 @@
 
 {% block extratitle %}{{ _('Search') }}{% endblock %}
 
+{% block extra_head %}
+<meta property="og:title" content="Aides-territoires | Toutes les aides pour les acteurs locaux  🏡" />
+<meta property="og:type" content="website" />
+<meta property="og:description" content="Trouvez les aides pertinentes pour financer et accompagner les projets de votre territoire" />
+<meta property="og:url" content="https://aides-territoires.beta.gouv.fr" />
+<meta property="og:site_name" content="Aides-territoires" />
+<meta property="og:image" content="https://aides-territoires.beta.gouv.fr/static/img/logo_AT_og.png" />
+<meta property="og:image:alt" content="Logo : Aides-territoires" />
+{% endblock %}
+
 {% block sectionid %}search{% endblock %}
 
 {% block content %}

--- a/src/templates/minisites/search_page.html
+++ b/src/templates/minisites/search_page.html
@@ -11,7 +11,7 @@
 <meta property="og:url" content="{{ site_url }}" />
 <meta property="og:site_name" content="{{ search_page.meta_title|default:search_page.title }}" />
 {% if search_page.meta_image %}
-<meta property="og:image" content="{{ site_url }}{{ search_page.meta_image.url }}" />
+<meta property="og:image" content="{{ search_page.meta_image.url }}" />
 {% endif %}
 <link rel="canonical" href="{{ canonical_url }}" />
 {% endblock %}

--- a/src/templates/search/general_search.html
+++ b/src/templates/search/general_search.html
@@ -3,6 +3,16 @@
 
 {% block extratitle %}Recherche – Trouver des aides{% endblock %}
 
+{% block extra_head %}
+<meta property="og:title" content="Aides-territoires | Toutes les aides pour les acteurs locaux  🏡" />
+<meta property="og:type" content="website" />
+<meta property="og:description" content="Trouvez les aides pertinentes pour financer et accompagner les projets de votre territoire" />
+<meta property="og:url" content="https://aides-territoires.beta.gouv.fr" />
+<meta property="og:site_name" content="Aides-territoires" />
+<meta property="og:image" content="https://aides-territoires.beta.gouv.fr/static/img/logo_AT_og.png" />
+<meta property="og:image:alt" content="Logo : Aides-territoires" />
+{% endblock %}
+
 {% block sectionid %}search-steps{% endblock %}
 
 {% block breadcrumbs %}


### PR DESCRIPTION
Ajout des balises Og sur les pages = 
- trouver des aides
- résultats aides
- page portails (balise og:image à fixer)
https://www.notion.so/Ajout-des-balises-OG-manquantes-ae079e3010084fc5ac6000d424b587b4