### PR TITLE
Conserver le filtre 'appel à projets' lorsque la recherche est complétée depuis le cartouche

### DIFF
--- a/src/templates/aids/_search_form.html
+++ b/src/templates/aids/_search_form.html
@@ -16,6 +16,7 @@
         {{ form.targeted_audiences.as_hidden }}
         {{ form.perimeter.as_hidden }}
         {{ form.themes.as_hidden }}
+        {{ form.call_for_projects_only.as_hidden }}
     {% endblock %}
 
     {% block other_actions %}


### PR DESCRIPTION
https://www.notion.so/BUG-Pb-lorsqu-on-veut-cumuler-dans-une-recherche-des-filtres-plus-de-crit-res-avec-des-filtres-d-88cffd045e2a461f8cc359d194492d75