### PR TITLE
Afficher uniquement le nom du collaborateur sur la page de détail d'un projet

### DIFF
--- a/src/templates/projects/project_detail.html
+++ b/src/templates/projects/project_detail.html
@@ -114,7 +114,7 @@
                                     {% if aidproject.creator == user %}
                                     Vous
                                     {% else %}
-                                    {{ aidproject.creator }}
+                                    {{ aidproject.creator.full_name }}
                                     {% endif %}
                                 </td>
                                 {% endif %}


### PR DESCRIPTION
https://www.notion.so/10d46008805d4aa89747ea969180b828?v=a2925c6c61874655ac01a13b4de10b59&p=6aedab302b54457aaf8319ee4a79b7bd