### PR TITLE
Remplace les logos du MTES et du MCT par le logo du gouvernement dans le footer

### DIFF
--- a/src/templates/_footer.html
+++ b/src/templates/_footer.html
@@ -39,13 +39,10 @@
 
 <footer class="fr-footer" role="contentinfo" id="footer">
     <div class="fr-container">
-        <div class="fr-footer__body fr-footer__body--operator">
+        <div class="fr-footer__body">
             <div class="fr-footer__brand">
-                <a href="https://www.ecologique-solidaire.gouv.fr/" title="Ministère de la Transition écologique">
-                    <img class="logo ministry-logo fr-responsive-img" src="/static/img/logo_mte.svg" alt="Logo du Ministère de la Transition écologique" />
-                </a>
-                <a class="fr-footer__brand-link fr-ml-3w" href="https://www.cohesion-territoires.gouv.fr/" title="Ministère de la Cohésion des Territoires et des Relations avec les Collectivités Territoriales">
-                    <img class="fr-footer__logo fr-responsive-img" src="/static/img/logo_mct.svg" alt="logo du Ministère de la Cohésion des Territoires et des Relations avec les Collectivités Territoriales">
+                <a class="fr-logo" href="https://www.gouvernement.fr" title="Site du Gouvernement Français">
+                    <span class="fr-logo__title">Gouvernement</span>
                 </a>
             </div>
             <div class="fr-footer__content">


### PR DESCRIPTION
https://www.notion.so/Dans-le-footer-remplacer-les-logos-des-2-minist-res-par-le-logo-Gouvernement-pour-tre-conforme--bea79a0ac7854159a5f61163627c7356