### PR TITLE
Vérifier le mot de passe actuel de l'utilisateur avant de lui permettre de le changer

### DIFF
--- a/src/accounts/factories.py
+++ b/src/accounts/factories.py
@@ -1,6 +1,5 @@
 import factory
 from factory.django import DjangoModelFactory
-
 from accounts.models import User
 
 
@@ -10,12 +9,12 @@ class UserFactory(DjangoModelFactory):
     class Meta:
         model = User
 
-    first_name = factory.Faker('name')
-    last_name = factory.Faker('name')
+    first_name = factory.Faker('first_name')
+    last_name = factory.Faker('last_name')
     email = factory.Faker('email')
     password = factory.PostGenerationMethodCall('set_password', 'DefaultPassword!')
     is_contributor = True
-    is_beneficiary = False
+    is_beneficiary = True
     beneficiary_function = "other"
     beneficiary_role = "Compte de test"
 

--- a/src/accounts/factories.py
+++ b/src/accounts/factories.py
@@ -13,11 +13,14 @@ class UserFactory(DjangoModelFactory):
     first_name = factory.Faker('name')
     last_name = factory.Faker('name')
     email = factory.Faker('email')
-    password = factory.PostGenerationMethodCall('set_password', 'pass')
+    password = factory.PostGenerationMethodCall('set_password', 'DefaultPassword!')
     is_contributor = True
+    is_beneficiary = False
+    beneficiary_function = "other"
+    beneficiary_role = "Compte de test"
 
 
 class ContributorFactory(UserFactory):
-    organization = factory.Faker('company')
-    role = factory.Faker('job')
-    contact_phone = factory.Faker('phone_number')
+    contributor_organization = factory.Faker('company')
+    contributor_role = factory.Faker('job')
+    contributor_contact_phone = factory.Faker('phone_number')

--- a/src/accounts/forms.py
+++ b/src/accounts/forms.py
@@ -138,6 +138,13 @@ class ContributorProfileForm(forms.ModelForm):
         widget=forms.PasswordInput(attrs={
             'placeholder': 'Laissez vide pour conserver votre mot de passe actuel'}))
 
+    new_password2 = forms.CharField(
+        label='Saisissez à nouveau le nouveau mot de passe',
+        required=False,
+        strip=False,
+        widget=forms.PasswordInput(attrs={
+            'placeholder': 'Laissez vide pour conserver votre mot de passe actuel'}))
+
     current_password = forms.CharField(
         label='Entrez votre mot de passe actuel',
         required=False,
@@ -149,7 +156,7 @@ class ContributorProfileForm(forms.ModelForm):
         model = User
         fields = [
             'first_name', 'last_name', 'email', 'is_contributor', 'is_beneficiary',
-            'beneficiary_function', 'beneficiary_role', 'new_password', 'current_password']
+            'beneficiary_function', 'beneficiary_role', 'new_password', 'new_password2', 'current_password']
         labels = {
             'first_name': 'Votre prénom',
             'last_name': 'Votre nom',
@@ -174,7 +181,9 @@ class ContributorProfileForm(forms.ModelForm):
         super()._post_clean()
         # Validate the password after self.instance is updated with form data by super().
         password = self.cleaned_data.get('new_password')
-        if password:
+        password2 = self.cleaned_data.get('new_password2')
+
+        if password and password == password2:
             try:
                 password_validation.validate_password(password, self.instance)
             except forms.ValidationError as error:
@@ -188,6 +197,8 @@ class ContributorProfileForm(forms.ModelForm):
             except forms.ValidationError as error:
                 self.add_error('current_password', error)
                 self.current_password_checked = False
+        elif password != password2:
+            self.add_error('new_password', 'Les mots de passe ne sont pas identiques')
 
     def save(self, commit=True):
         user = super().save(commit=False)

--- a/src/accounts/forms.py
+++ b/src/accounts/forms.py
@@ -183,7 +183,6 @@ class ContributorProfileForm(forms.ModelForm):
             # if new_password is set, we also need to check the current_password
             current_password = self.cleaned_data.get("current_password")
             try:
-                print(self.instance)
                 self.current_password_checked = check_current_password(
                     current_password, self.instance.password)
             except forms.ValidationError as error:

--- a/src/accounts/forms.py
+++ b/src/accounts/forms.py
@@ -5,6 +5,7 @@ from django.contrib.auth import password_validation
 from model_utils import Choices
 
 from accounts.models import User
+from accounts.utils import check_current_password
 
 
 class RegisterForm(UserCreationForm):
@@ -137,11 +138,18 @@ class ContributorProfileForm(forms.ModelForm):
         widget=forms.PasswordInput(attrs={
             'placeholder': 'Laissez vide pour conserver votre mot de passe actuel'}))
 
+    current_password = forms.CharField(
+        label='Entrez votre mot de passe actuel',
+        required=False,
+        strip=False,
+        widget=forms.PasswordInput(attrs={
+            'placeholder': 'À remplir en cas de changement de mot de passe'}))
+
     class Meta:
         model = User
         fields = [
             'first_name', 'last_name', 'email', 'is_contributor', 'is_beneficiary',
-            'beneficiary_function', 'beneficiary_role', 'new_password']
+            'beneficiary_function', 'beneficiary_role', 'new_password', 'current_password']
         labels = {
             'first_name': 'Votre prénom',
             'last_name': 'Votre nom',
@@ -172,11 +180,21 @@ class ContributorProfileForm(forms.ModelForm):
             except forms.ValidationError as error:
                 self.add_error('new_password', error)
 
+            # if new_password is set, we also need to check the current_password
+            current_password = self.cleaned_data.get("current_password")
+            try:
+                print(self.instance)
+                self.current_password_checked = check_current_password(
+                    current_password, self.instance.password)
+            except forms.ValidationError as error:
+                self.add_error('current_password', error)
+                self.current_password_checked = False
+
     def save(self, commit=True):
         user = super().save(commit=False)
 
         new_password = self.cleaned_data['new_password']
-        if new_password:
+        if new_password and self.current_password_checked:
             user.set_password(new_password)
 
         if commit:

--- a/src/accounts/utils.py
+++ b/src/accounts/utils.py
@@ -1,0 +1,15 @@
+from django.forms import ValidationError
+
+from django.contrib.auth.hashers import check_password
+
+
+def check_current_password(entered_password, registered_password):
+    """Check if the user entered a valid password"""
+    if not entered_password:
+        raise ValidationError(
+            "Vous devez entrer votre mot de passe actuel pour pouvoir le changer.")
+    else:
+        if check_password(entered_password, registered_password):
+            return True
+        else:
+            raise ValidationError("Le mot de passe actuel entré est incorrect.")

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -11,6 +11,7 @@ from backers.factories import BackerFactory
 from geofr.models import Perimeter
 from geofr.factories import PerimeterFactory
 from categories.factories import CategoryFactory
+from organizations.models import Organization
 
 
 @pytest.fixture(scope='session')
@@ -53,7 +54,13 @@ def user_client(user, client):
 def contributor():
     """Generates a valid and active contributor."""
 
+    # We may need an OrganizationFactory when the organizations app has a test suite
+    sample_org = Organization(name="Sample org")
+    sample_org.save()
+
     user = ContributorFactory()
+    user.beneficiary_organization = sample_org
+    user.save()
     return user
 
 

--- a/src/templates/accounts/contributor_profile.html
+++ b/src/templates/accounts/contributor_profile.html
@@ -67,6 +67,7 @@
                 </div>
                 {% include '_field_snippet.html' with field=form.current_password %}
                 {% include '_field_snippet.html' with field=form.new_password %}
+                {% include '_field_snippet.html' with field=form.new_password2 %}
                 <button type="submit" class="fr-btn">Mettre à jour mes données</button>
             </form>
         </div>

--- a/src/templates/accounts/contributor_profile.html
+++ b/src/templates/accounts/contributor_profile.html
@@ -65,6 +65,7 @@
                         </div>
                     </fieldset>    
                 </div>
+                {% include '_field_snippet.html' with field=form.current_password %}
                 {% include '_field_snippet.html' with field=form.new_password %}
                 <button type="submit" class="fr-btn">Mettre à jour mes données</button>
             </form>


### PR DESCRIPTION
cf https://www.notion.so/V-rifier-le-mot-de-passe-de-l-utilisateur-avant-de-lui-permettre-de-le-changer-f446147dcb414e9ca7efd33eab68a07f

- Ajout d'une vérification du mot de passe de l'utlisateur avant changement de celui-ci
- Correction de plusieurs tests liés aux comptes utilisateurs.