### PR TITLE
Ajout d'un second TEMPLATE dans les paramètres locaux

### DIFF
--- a/src/core/settings/base.py
+++ b/src/core/settings/base.py
@@ -188,6 +188,7 @@ FORM_RENDERER = 'django.forms.renderers.TemplatesSetting'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'NAME': 'BASE',
         'DIRS': [DJANGO_ROOT.child('templates')],
         'OPTIONS': {
             'debug': False,
@@ -326,7 +327,7 @@ SIB_WELCOME_EMAIL_ENABLED = False
 SIB_WELCOME_EMAIL_TEMPLATE_ID = 0
 SIB_PUBLICATION_EMAIL_ENABLED = False
 SIB_PUBLICATION_EMAIL_TEMPLATE_ID = 0
-SIB_ALERT_CONFIRMATION_EMAIL_TEMPLATE_ID=0
+SIB_ALERT_CONFIRMATION_EMAIL_TEMPLATE_ID = 0
 SIB_NEWSLETTER_CONFIRM_TEMPLATE_ID = 0
 EXPORT_CONTACTS_ENABLED = False
 

--- a/src/core/settings/local.py
+++ b/src/core/settings/local.py
@@ -110,3 +110,33 @@ AWS_STORAGE_BUCKET_NAME = env('AWS_STORAGE_BUCKET_NAME', default='')
 AWS_S3_REGION_NAME = env('AWS_S3_REGION_NAME', default='')
 AWS_DEFAULT_ACL = 'public-read'
 AWS_QUERYSTRING_AUTH = False
+
+"""
+Adding a second template just for the django_debug_toolbar which requires:
+- "APP_DIRS": True
+- which is incompatible with "loaders", so it is removed here
+- (and "loader" itself is mandatory for django-admin-tools)
+"""
+TEMPLATES += [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        "NAME": "For django_debug_toolbar",
+        "APP_DIRS": True,
+        'OPTIONS': {
+            'debug': True,
+            'context_processors': [
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+                'core.context_processors.integration',
+                'core.context_processors.contact_data',
+                'core.context_processors.admin_stats',
+                'core.context_processors.contributor_stats',
+            ],
+            'libraries': {
+                'form_utils': 'core.templatetags.form_utils',
+            }
+        },
+    }
+]


### PR DESCRIPTION
Ajout d'une seconde entrée "TEMPLATE" dans les paramètres locaux (core/settings/local.py) pour permettre à django_debug_toolbar de fonctionner sans avoir à jongler entre elle et l'extension django_admin_tools qui a un paramétrage incompatible)

https://www.notion.so/La-debug_toolbar-ne-s-affiche-plus-caa5e9fd5ff641c68577ebc93c0d9e2f