### PR TITLE
Fiche Détail des Aides : Remplace les acronymes AAP/AMI par les noms détaillés

### DIFF
--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -176,12 +176,7 @@
                             </div>
                             <div class="fr-col-10">
                                 <h3 class="fr-h6">
-                                    <acronym title="{{ _('Call for project') }}">
-                                        AAP
-                                    </acronym> /
-                                    <acronym title="{{ _('Call for expression of interest') }}">
-                                        AMI
-                                    </acronym>
+                                    Appel à projets (AAP) / Appel à manifestation d’intérêt (AMI)
                                 </h3>    
                             </div>
                         </div>


### PR DESCRIPTION
https://www.notion.so/Dans-la-fiche-aide-remplacer-l-acronyme-AAP-AMI-par-Appel-projets-AAP-Appel-manifestat-8e2b6cc6025d4a2c921e2de1d969d58b