### PR TITLE
Ajouter une colonne “porteur d’aide” dans le tableau de détail des aides d'un projet

### DIFF
--- a/src/templates/projects/project_detail.html
+++ b/src/templates/projects/project_detail.html
@@ -81,6 +81,7 @@
                             <th scope="col" class="fr-text">Nom</th>
                             <th scope="col" class="fr-text">Echéance</th>
                             <th scope="col" class="fr-text">Type d'aide</th>
+                            <th scope="col" class="fr-text">Porteur</th>
                             <th scope="col" class="fr-text">Ajouté&nbsp;le</th>
                             <th scope="col" class="fr-text">Par</th>
                             <th scope="col" class="fr-text">Action</th>
@@ -105,6 +106,17 @@
                                 <td class="fr-text">
                                     {% choices_display aid 'aid_types' %}
                                 </td>
+                                <td class="fr-text">
+                                    <ul>
+                                    {% for financer in aid.financers.all %}
+                                        <li>
+                                            <a href="{% url 'backer_detail_view' financer.pk financer.slug %}" target="_blank" rel="noopener">
+                                            {{ financer.name }}
+                                            </a>
+                                        </li>
+                                    {% endfor %}
+                                    <ul>
+                                </td>       
                                 {% for aidproject in AidProject %}
                                 {% if aidproject.aid == aid %}
                                 <td class="fr-text">


### PR DESCRIPTION
https://www.notion.so/Ajouter-une-colonne-porteur-d-aide-sur-les-aides-sauvegard-es-dans-le-compte-utilisateur-8b4b99516e6b4e3a9875495c00e73619