### PR TITLE
Affichage des sous-thématiques associées à une aide sous forme de tag dans la page détail d'une aide

### DIFF
--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -52,23 +52,6 @@
             {% endif %}
 
             <h1> {{ aid.name }} </h1>
-            {% if aid.categories %}
-            {% regroup aid.categories.all by theme as theme_list %}
-            <ul class="aid-categories fr-list__none">
-                {% for theme in theme_list %}
-                <li class="theme">
-                    <strong class="fr-uppercase">
-                        {{ theme.grouper }}
-                    </strong>
-                    <ul class="fr-list__none fr-display__inline fr-p-0">
-                        {% for category in theme.list %}
-                        <li class="category fr-display__inline">{{ category }}</li>
-                        {% endfor %}
-                    </ul>
-                </li>
-                {% endfor %}
-            </ul>
-            {% endif %}
 
             {% if not aid.is_published %}
             <div class="danger fr-background-alt-pink fr-p-3w">
@@ -391,6 +374,18 @@
                         </div>
                     </div>
                     {% endif %}
+
+                    {% if aid.categories %}
+                    {% regroup aid.categories.all by theme as theme_list %}
+                    <div class="fr-list__none">
+                        {% for theme in theme_list %}
+                        {% for category in theme.list %}
+                        <p class="fr-tag fr-mb-1w fr-tag--icon-left">{{ category }}</p>
+                        {% endfor %}
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+        
                 </div>
 
                 <div class="aid-details fr-col-12 fr-col-md-8 fr-pb-3w fr-px-3w">

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -380,12 +380,12 @@
                     <div class="fr-list__none">
                         {% for theme in theme_list %}
                         {% for category in theme.list %}
-                        <p class="fr-tag fr-mb-1w fr-tag--icon-left">{{ category }}</p>
+                        <a href="{% url 'search_view' %}?text={{ category }}" class="fr-tag fr-mb-1w" target="blank">{{ category }}</a>
                         {% endfor %}
                         {% endfor %}
                         {% if aid.keywords.all %}
                         {% for keyword in aid.keywords.all %}
-                        <p class="fr-tag fr-mb-1w fr-tag--icon-left">{{ keyword }}</p>
+                        <a href="{% url 'search_view' %}?text={{ keyword }}" class="fr-tag fr-mb-1w" target="blank">{{ keyword }}</a>
                         {% endfor %}
                         {% endif %}
                     </div>

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -383,6 +383,11 @@
                         <p class="fr-tag fr-mb-1w fr-tag--icon-left">{{ category }}</p>
                         {% endfor %}
                         {% endfor %}
+                        {% if aid.keywords.all %}
+                        {% for keyword in aid.keywords.all %}
+                        <p class="fr-tag fr-mb-1w fr-tag--icon-left">{{ keyword }}</p>
+                        {% endfor %}
+                        {% endif %}
                     </div>
                     {% endif %}
         


### PR DESCRIPTION
https://www.notion.so/Afficher-les-mots-cl-s-dans-la-page-d-tails-de-l-aide-4c03c54c6a0442888435e1926323a761