### PR TITLE
 Affichage des sous-thématiques/mots clés associés à une aide sous forme de tag dans la page détail d'une aide

### DIFF
--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -56,24 +56,6 @@
     {% else %}
     <h1> {{ aid.name }} </h1>
     {% endif %}
-    
-    {% if aid.categories %}
-    {% regroup aid.categories.all by theme as theme_list %}
-    <ul class="aid-categories fr-list__none">
-        {% for theme in theme_list %}
-        <li class="theme">
-            <strong class="fr-uppercase">
-                {{ theme.grouper }}
-            </strong>
-            <ul class="fr-list__none fr-display__inline fr-p-0">
-                {% for category in theme.list %}
-                <li class="category fr-display__inline">{{ category }}</li>
-                {% endfor %}
-            </ul>
-        </li>
-        {% endfor %}
-    </ul>
-    {% endif %}
 
     {% if not aid.is_published %}
     <div class="danger fr-background-alt-pink fr-p-3w">
@@ -393,6 +375,22 @@
                     </h2>
                     <p class="fr-mb-0">Visitez <a href="https://www.aides-entreprises.fr/" target="_blank" rel="noopener">Aides-entreprises</a></p>    
                 </div>
+            </div>
+            {% endif %}
+
+            {% if aid.categories %}
+            {% regroup aid.categories.all by theme as theme_list %}
+            <div class="fr-list__none">
+                {% for theme in theme_list %}
+                {% for category in theme.list %}
+                <a href="{% url 'search_view' %}?text={{ category }}" class="fr-tag fr-mb-1w" target="blank">{{ category }}</a>
+                {% endfor %}
+                {% endfor %}
+                {% if aid.keywords.all %}
+                {% for keyword in aid.keywords.all %}
+                <a href="{% url 'search_view' %}?text={{ keyword }}" class="fr-tag fr-mb-1w" target="blank">{{ keyword }}</a>
+                {% endfor %}
+                {% endif %}
             </div>
             {% endif %}
         </div>


### PR DESCRIPTION
https://www.notion.so/Afficher-les-mots-cl-s-dans-la-page-d-tails-de-l-aide-4c03c54c6a0442888435e1926323a761