### PR TITLE
Ajouter les badges liés à l’échéance de l’aide dans le tableau des projets

### DIFF
--- a/src/templates/projects/project_detail.html
+++ b/src/templates/projects/project_detail.html
@@ -97,11 +97,16 @@
                                     </a>
                                 </td>
                                 <td class="fr-text">
-                                {% if aid.has_calendar %}
-                                    {% if aid.submission_deadline %}
-                                        {{ aid.submission_deadline|date }}
+                                    <span>{{ aid.submission_deadline|date:'d/m/Y' }}</span>
+                                    {% if aid.is_ongoing %}
+                                        <p class="fr-badge fr-badge--info fr-badge--sm">Permanente</p>
+                                    {% elif aid.has_approaching_deadline %}
+                                        <p class="fr-badge fr-badge--new fr-badge--sm">Échéance proche</p>                       
+                                    {% elif aid.has_expired %}
+                                        <p class="fr-badge fr-badge--warning fr-badge--sm">Expirée</p>
                                     {% endif %}
-                                {% endif %}
+                               </td>
+
                                 </td>
                                 <td class="fr-text">
                                     {% choices_display aid 'aid_types' %}


### PR DESCRIPTION
https://www.notion.so/Ajouter-les-badges-li-s-l-ch-ance-de-l-aide-dans-le-tableau-des-projets-9c1be273c8d249aa89b6a9d4fd5d2a3a