### PR TITLE
Compte utilisateur : simplification de l’inscription (suppression de la division en 2 étapes) 

### DIFF
--- a/src/accounts/forms.py
+++ b/src/accounts/forms.py
@@ -1,12 +1,14 @@
 from django import forms
 from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
 from django.contrib.auth import password_validation
+from core.forms.fields import AutocompleteModelChoiceField
 
 from model_utils import Choices
 
 from accounts.models import User
 from accounts.utils import check_current_password
 from projects.models import Project
+from geofr.models import Perimeter
 
 from dsfr.forms import DsfrBaseForm
 
@@ -47,8 +49,12 @@ class RegisterForm(UserCreationForm, DsfrBaseForm):
     )
     is_contributor = forms.BooleanField(label="Publier des aides", required=False)
     is_beneficiary = forms.BooleanField(label="Trouver des aides", required=False)
+    organization_name = forms.CharField(label="Nom de votre structure", required=True)
     organization_type = forms.ChoiceField(
         label="Vous êtes un/une", required=True, choices=ORGANIZATION_TYPE
+    )
+    perimeter = AutocompleteModelChoiceField(
+        label="Votre territoire", queryset=Perimeter.objects.all(), required=True
     )
 
     class Meta:
@@ -63,7 +69,9 @@ class RegisterForm(UserCreationForm, DsfrBaseForm):
             "beneficiary_function",
             "is_contributor",
             "is_beneficiary",
+            "organization_name",
             "organization_type",
+            "perimeter",
         ]
 
     def __init__(self, *args, **kwargs):

--- a/src/accounts/tests/test_views.py
+++ b/src/accounts/tests/test_views.py
@@ -140,7 +140,7 @@ def test_register_form_is_accessible_to_anonymous_user(client):
     assert res.status_code == 200
 
 
-def test_register_form_expects_valid_data(client):
+def test_register_form_expects_valid_data(client, perimeters):
     register_url = reverse("register")
     res = client.post(
         register_url,
@@ -151,7 +151,7 @@ def test_register_form_expects_valid_data(client):
             "password1": "Gloubiboulga",
             "password2": "Gloubiboulga",
             "organization_type": "farmer",
-            "perimeter": "79138-chanterac",
+            "perimeter": perimeters['france'].id,
             "organization_name": "L'île aux enfants",
             "beneficiary_role": "Pas de la tarte",
             "beneficiary_function": "other",
@@ -171,7 +171,7 @@ def test_register_form_expects_valid_data(client):
             "password2": "Gloubiboulga",
             "email": "tartiflette",
             "organization_type": "farmer",
-            "perimeter": "79138-chanterac",
+            "perimeter": perimeters['france'].id,
             "organization_name": "L'île aux enfants",
             "beneficiary_role": "Pas de la tarte",
             "beneficiary_function": "other",
@@ -183,7 +183,7 @@ def test_register_form_expects_valid_data(client):
     assert "Saisissez une adresse e-mail valide." in res.content.decode()
 
 
-def test_register_form_with_unique_email(client, user, mailoutbox):
+def test_register_form_with_unique_email(client, user, mailoutbox, perimeters):
     """When registering with an existing email, there is a warning"""
 
     register_url = reverse("register")
@@ -196,7 +196,7 @@ def test_register_form_with_unique_email(client, user, mailoutbox):
             "password1": "Gloubiboulga",
             "password2": "Gloubiboulga",
             "organization_type": "farmer",
-            "perimeter": 1,
+            "perimeter": perimeters['france'].id,
             "organization_name": "L'île aux enfants",
             "beneficiary_role": "Pas de la tarte",
             "beneficiary_function": "other",
@@ -211,7 +211,7 @@ def test_register_form_with_unique_email(client, user, mailoutbox):
     )
 
 
-def test_register_form(client, mailoutbox):
+def test_register_form(client, mailoutbox, perimeters):
     users = User.objects.all()
     organizations = Organization.objects.all()
     assert users.count() == 0
@@ -226,7 +226,7 @@ def test_register_form(client, mailoutbox):
             "email": "olga@test.com",
             "password1": "Gloubiboulga",
             "password2": "Gloubiboulga",
-            "perimeter": 1,
+            "perimeter": perimeters['france'].id,
             "organization_name": "L'île aux enfants",
             "organization_type": "farmer",
             "beneficiary_role": "Pas de la tarte",
@@ -254,7 +254,7 @@ def test_register_form(client, mailoutbox):
     assert mail.subject == "Connexion à Aides-territoires"
 
 
-def test_register_form_converts_email_to_lowercase(client):
+def test_register_form_converts_email_to_lowercase(client, perimeters):
     users = User.objects.all()
     assert users.count() == 0
 
@@ -267,7 +267,7 @@ def test_register_form_converts_email_to_lowercase(client):
             "email": "OLGA@Test.Com",
             "password1": "Gloubiboulga",
             "password2": "Gloubiboulga",
-            "perimeter": 1,
+            "perimeter": perimeters['france'].id,
             "organization_name": "L'île aux enfants",
             "organization_type": "farmer",
             "beneficiary_role": "Pas de la tarte",

--- a/src/organizations/views.py
+++ b/src/organizations/views.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.views.generic import CreateView, UpdateView
 from django.urls import reverse
 from django.contrib import messages
@@ -9,9 +8,7 @@ from django.core.exceptions import PermissionDenied
 from accounts.mixins import ContributorAndProfileCompleteRequiredMixin
 
 from organizations.forms import OrganizationCreateForm, OrganizationUpdateForm
-from accounts.tasks import send_connection_email
 from accounts.models import User
-from analytics.utils import track_goal
 from organizations.models import Organization
 
 
@@ -23,10 +20,7 @@ class OrganizationCreateView(CreateView):
 
     def form_valid(self, form):
 
-        if self.request.session.get("USER_EMAIL"):
-            user_email = self.request.session.get("USER_EMAIL")
-            user_organization_type = self.request.session.get("USER_ORGANIZATION_TYPE")
-        elif self.request.user.email:
+        if self.request.user.email:
             user_email = self.request.user.email
             user_organization_type = self.request.POST.get("organization_type")
         else:
@@ -44,16 +38,7 @@ class OrganizationCreateView(CreateView):
         organization.beneficiaries.add(user_id)
         User.objects.filter(pk=user_id).update(beneficiary_organization=organization.pk)
 
-        if self.request.session.get("USER_EMAIL"):
-            send_connection_email.delay(user_email)
-            track_goal(self.request.session, settings.GOAL_REGISTER_ID)
-            msg = "Vous êtes bien enregistré&nbsp;!"
-            messages.success(self.request, msg)
-            success_url = reverse("register_success")
-            self.request.session.pop("USER_EMAIL")
-            self.request.session.pop("USER_ORGANIZATION_TYPE")
-
-        elif self.request.user.email:
+        if self.request.user.email:
             msg = "Votre profil a bien été mis à jour !"
             messages.success(self.request, msg)
             success_url = reverse("user_dashboard")

--- a/src/static/js/aids/perimeter_autocomplete.js
+++ b/src/static/js/aids/perimeter_autocomplete.js
@@ -1,8 +1,8 @@
 $(document).ready(function () {
 
     // hide "custom" perimeters in the user part of the website
-    var RESTRICT_TO_VISIBLE_PERIMETERS = $('#perimeter').length || $('#search-form').length || $('#advanced-search-form').length || $('#general_search_form').length;
-    var RESTRICT_TO_NON_OBSOLETE_PERIMETERS = $('#perimeter').length || $('#search-form').length || $('#advanced-search-form').length || $('#general_search_form').length;
+    var RESTRICT_TO_VISIBLE_PERIMETERS = $('#perimeter').length || $('#search-form').length || $('#advanced-search-form').length || $('#general_search_form').length || $('#register-page').length;
+    var RESTRICT_TO_NON_OBSOLETE_PERIMETERS = $('#perimeter').length || $('#search-form').length || $('#advanced-search-form').length || $('#general_search_form').length || $('#register-page').length;
 
     $('select#id_perimeter').select2({
         placeholder: catalog.perimeter_placeholder,

--- a/src/templates/accounts/register.html
+++ b/src/templates/accounts/register.html
@@ -1,5 +1,5 @@
 {% extends "_base.html" %}
-{% load static form_utils compress %}
+{% load i18n static form_utils compress dsfr_tags %}
 
 {% block extraclasses %}light{% endblock extraclasses %}
 
@@ -79,6 +79,8 @@
                                         <fieldset>
                                             <legend>Informations professionnelles</legend>
 
+                                            {% include '_field_snippet.html' with field=form.organization_name %}
+
                                             <div id="form-group-organization_type" class="fr-input-group required ">
                                                 <label for="id_organization_type">Vous êtes un/une</label>
                                                 <select class="fr-select" name="organization_type" id="id_organization_type">
@@ -113,6 +115,8 @@
     
                                                 {% include '_field_snippet.html' with field=form.beneficiary_role %}
                                             </div>
+
+                                            {% include '_field_snippet.html' with field=form.perimeter %}
 
                                             <div class="fr-form-group">
                                                 <fieldset class="fr-fieldset">
@@ -160,8 +164,17 @@
 </div>
 {% endblock content %}
 
+{% block extra_css %}
+{% compress css %}
+{% endcompress %}
+{% endblock extra_css %}
+
 {% block extra_js %}
 {% compress js %}
 <script src="{% static 'js/accounts/toggle_beneficiary_related_fields.js' %}"></script>
+<script src="{% static 'select2/dist/js/select2.js' %}"></script>
+<script src="{% static 'select2/dist/js/i18n/fr.js' %}"></script>
+<script src="{% static 'js/aids/perimeter_autocomplete.js' %}"></script>
+<script src="{% static 'js/aids/select2_dsfr.js' %}"></script>
 {% endcompress %}
 {% endblock extra_js %}

--- a/src/templates/organizations/create.html
+++ b/src/templates/organizations/create.html
@@ -11,13 +11,8 @@
 <div class="fr-container fr-my-5w">
     <div class="fr-grid-row fr-grid-row--center">
         <div class="fr-col-md-8">
-            {% if request.session.USER_NAME %}
-            <h1 class="fr-mb-5w">Bienvenue {{ request.session.USER_NAME }} !</h1>
-            <h2 class="fr-h3">Merci de renseigner les informations de votre structure pour finaliser votre inscription</h2>
-            {% else %}
             <h1 class="fr-mb-5w">Bonjour {{ request.user.full_name }} !</h1>
             <h2 class="fr-h3">Merci de mettre à jour les informations de votre structure avant d’accéder à votre espace</h2>
-            {% endif %}
 
             <form method="post" novalidate class="fr-mt-5w">
                 {% csrf_token %}
@@ -29,10 +24,7 @@
                     <legend class="fr-pt-4w">Informations professionnelles</legend>
                     {% include '_field_snippet.html' with field=form.name %}
                     {% include '_field_snippet.html' with field=form.perimeter %}
-
-                    {% if not request.session.USER_NAME %}
                     {% include '_field_snippet.html' with field=form.organization_type required=required %}
-                    {% endif %}
                 </fieldset>
 
                 <button type="submit" class="fr-btn fr-mb-5w fr-mt-1w">Finaliser mon inscription</button>


### PR DESCRIPTION
https://www.notion.so/Simplification-de-l-inscription-suppression-de-la-division-en-2-tapes-953c9e9c44b4467786603f95cb09bc8c

- Fusion du formulaire en deux étapes afin de faciliter l'inscription
- Mise à jour des tests correspondant à l'inscription
- Amélioration des tests avec utilisation d'une valeur issue de la liste `perimeters` pour le champ `perimeter` plutôt que l'utilisation d'un `id` dont l'existence n'est pas vérifiée (cela posait problème notamment dans le cadre du lancement de la commande `py.test --reuse-db`) >> cette partie a été réalisée avec @davidbgk :) 