### PR TITLE
Correction de la documentation pour lancer des tests

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -117,7 +117,7 @@ Il faut aussi installer l'extension pg_trgm :
     psql -d template1 -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;' -U postgres
     psql -d template1 -c 'CREATE EXTENSION IF NOT EXISTS unaccent;' -U postgres
     psql -d template1 -c 'CREATE EXTENSION IF NOT EXISTS btree_gin;' -U postgres
-    psql -d aides -c 'CREATE TEXT SEARCH CONFIGURATION french_unaccent( COPY = french ); ALTER TEXT SEARCH CONFIGURATION french_unaccent ALTER MAPPING FOR hword, hword_part, word WITH unaccent, french_stem;' -U postgres
+    psql -d template1 -c 'CREATE TEXT SEARCH CONFIGURATION french_unaccent( COPY = french ); ALTER TEXT SEARCH CONFIGURATION french_unaccent ALTER MAPPING FOR hword, hword_part, word WITH unaccent, french_stem;' -U postgres
 
 En suivant l'utilisateur `aides` peut lancer les tests :
 

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -14,19 +14,6 @@ from categories.factories import CategoryFactory
 from organizations.models import Organization
 
 
-@pytest.fixture(scope="session")
-def django_db_setup(django_db_setup, django_db_blocker):
-    with django_db_blocker.unblock():
-        with connection.cursor() as cursor:
-            cursor.execute(
-                """
-                CREATE TEXT SEARCH CONFIGURATION french_unaccent( COPY = french );
-                ALTER TEXT SEARCH CONFIGURATION french_unaccent
-                ALTER MAPPING FOR hword, hword_part, word WITH unaccent, french_stem;
-                """
-            )
-
-
 @pytest.fixture(scope="module")
 def browser():
     opts = Options()


### PR DESCRIPTION
La fixture `django_db_setup` est rendue inutile lorsqu'on applique la commande sur `template1` qui est le template par défaut pour créer la base de tests.

MAIS, il faut lancer la commande avec les bons paramètres, ce qui a conduit à modifier la documentation d'ONBOARDING.

