### PR TITLE
Redirige france-relance-mayotte vers le portail mayotte

### DIFF
--- a/src/core/settings/base.py
+++ b/src/core/settings/base.py
@@ -387,6 +387,7 @@ REDIRECT_MINISITES_TO_EXTERNAL_URL = [
     ),
     ("france-relance-guyane", "https://guyane.aides-territoires.beta.gouv.fr"),
     ("france-relance-martinique", "https://martinique.aides-territoires.beta.gouv.fr"),
+    ("france-relance-mayotte", "https://mayotte.aides-territoires.beta.gouv.fr"),
 ]
 
 # ADDNA


### PR DESCRIPTION
https://www.notion.so/Changer-l-URL-https-france-relance-mayotte-aides-territoires-beta-gouv-fr-en-https-mayotte--7bd00dfc15e14e40b05e2cc7f41aae5a