### PR TITLE
Répare la fonctionnalité d'inscription à la Newsletter

### DIFF
--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -253,7 +253,7 @@ class UserApiTokenView(ContributorAndProfileCompleteRequiredMixin, TemplateView)
 class SubscribeNewsletter(View):
     def get(self, request):
         """
-        Here we want to allow user to unsubscribe to the newsletter.
+        Here we want to allow user to subscribe to the newsletter.
         """
         SIB_NEWSLETTER_ID = settings.SIB_NEWSLETTER_ID.split(", ")
         SIB_NEWSLETTER_ID = [int(i) for i in SIB_NEWSLETTER_ID]
@@ -283,9 +283,11 @@ class SubscribeNewsletter(View):
         response = requests.request("POST", url, json=payload, headers=headers)
 
         if response and any((response.status_code == 201, response.status_code == 204)):
-            msg = "Votre demande d'inscription à la newsletter a bien été prise en compte."
-            "<strong>Afin de finaliser votre inscription il vous reste à cliquer sur le lien"
-            "de confirmation présent dans l'e-mail que vous allez recevoir.</strong>"
+            msg = (
+                "Votre demande d'inscription à la newsletter a bien été prise en compte. <br/>"
+                "<strong>Afin de finaliser votre inscription il vous reste à cliquer sur le lien "
+                "de confirmation présent dans l'e-mail que vous allez recevoir.</strong>"
+            )
             messages.success(self.request, msg)
         else:
             msg = "Une erreur s'est produite lors de votre inscription à la newsletter"


### PR DESCRIPTION
Le message de succès lors de l'inscription à la newsletter était tronqué (en cause une mauvais gestion des retours à la ligne dans le code). L'utilisateur n'était donc pas informé qu'un email avec un lien d'activation, nécessaire à la finalisation de son inscription, lui était envoyé)