### PR TITLE
Chargement des images non visibles en mode lazy

### DIFF
--- a/src/templates/_footer.html
+++ b/src/templates/_footer.html
@@ -72,22 +72,22 @@
             <div class="fr-footer__partners-logos">
                 <div class="fr-footer__partners-main">
                             <a class="fr-footer__partners-link" href="https://agence-cohesion-territoires.gouv.fr/" title="Agence nationale de la cohésion des territoires">
-                                <img class="fr-footer__logo" src="{% static 'img/logo-anct.svg' %}" alt="" />
+                                <img class="fr-footer__logo" src="{% static 'img/logo-anct.svg' %}" alt="" loading="lazy" />
                             </a>
                             <a class="fr-footer__partners-link" href="https://www.francemobilites.fr/" title="France Mobilités">
-                                <img class="fr-footer__logo" src="{% static 'img/logo-francemobilites.svg' %}" alt="" />
+                                <img class="fr-footer__logo" src="{% static 'img/logo-francemobilites.svg' %}" alt="" loading="lazy" />
                             </a>
                 </div>
                 <div class="fr-footer__partners-sub">
                     <ul>
                         <li>
                             <a class="fr-footer__partners-link" href="https://www.cohesion-territoires.gouv.fr/la-fabrique-numerique-lincubateur-de-services-numeriques-du-pole-ministeriel" title="Fabrique Numérique">
-                                <img class="fr-footer__logo" src="{% static 'img/logo-fabriquenumerique.svg' %}" alt="" />
+                                <img class="fr-footer__logo" src="{% static 'img/logo-fabriquenumerique.svg' %}" alt="" loading="lazy" />
                             </a>
                         </li>
                         <li>
                             <a class="fr-footer__partners-link" href="https://beta.gouv.fr/" title="Beta.gouv.fr">
-                                <img class="fr-footer__logo" src="{% static 'img/logo-betagouvfr.svg' %}" alt="" />
+                                <img class="fr-footer__logo" src="{% static 'img/logo-betagouvfr.svg' %}" alt="" loading="lazy" />
                             </a>
                         </li>
                     </ul>

--- a/src/templates/blog/post_list.html
+++ b/src/templates/blog/post_list.html
@@ -80,7 +80,7 @@
                         {% if post.logo %}
                             <div class="fr-card__header">
                                 <div class="fr-card__img">
-                                <img src="{{ post.logo.url }}" class="fr-responsive-img" alt="">
+                                <img src="{{ post.logo.url }}" class="fr-responsive-img" alt="" loading="lazy">
                                 </div>
                             </div>
                         {% endif %}

--- a/src/templates/home/home.html
+++ b/src/templates/home/home.html
@@ -117,7 +117,7 @@
                             </div>
                             <div class="fr-card__header">
                                 <div class="fr-card__img">
-                                    <img class="fr-responsive-img" src="{% static 'img/portails.jpg' %}" alt="" />
+                                    <img class="fr-responsive-img" src="{% static 'img/portails.jpg' %}" alt="" loading="lazy" />
                                 </div>
                             </div>
                         </div>
@@ -135,7 +135,7 @@
                             </div>
                             <div class="fr-card__header">
                                 <div class="fr-card__img">
-                                    <img class="fr-responsive-img" src="{% static 'img/europe.jpg' %}" alt="" />
+                                    <img class="fr-responsive-img" src="{% static 'img/europe.jpg' %}" alt="" loading="lazy" />
                                 </div>
                             </div>
                         </div>
@@ -153,7 +153,7 @@
                             </div>
                             <div class="fr-card__header">
                                 <div class="fr-card__img">
-                                    <img class="fr-responsive-img" src="{% static 'img/plan-de-relance.jpg' %}" alt="" />
+                                    <img class="fr-responsive-img" src="{% static 'img/plan-de-relance.jpg' %}" alt="" loading="lazy" />
                                 </div>
                             </div>
                         </div>
@@ -175,7 +175,7 @@
                                 <div class="fr-col-xs-12 fr-p-3w">
                                     <a href="{{ selected_backer.get_absolute_url }}" class="at-link__nodecorator">
                                     {% if selected_backer.logo %}
-                                        <img src="{{ selected_backer.logo.url }}" alt="Logo : {{ selected_backer.name }} " />
+                                        <img src="{{ selected_backer.logo.url }}" alt="Logo : {{ selected_backer.name }} " loading="lazy" />
                                     {% endif %}
                                     </a>
                                 </div>


### PR DESCRIPTION
Permet de réduire le temps de chargement des pages, les images qui ne sont pas visibles sans scroller sont ainsi chargées uniquement lors du défilement lorsqu’elles deviennent visibles.