### PR TITLE
Fix : suggérer une aide depuis la page détail d'une aide

### DIFF
--- a/src/static/js/aids/favorite_project_checkbox_required.js
+++ b/src/static/js/aids/favorite_project_checkbox_required.js
@@ -1,7 +1,7 @@
 $(document).ready(function () {
     // Disable submit button until at least one enabled checkbox was checked
-    var submitBtn = $('form#suggest-aid-modal-form button[type=submit]');
-    var checkboxesEnabled = $(".fr-form-group input[type='checkbox']:not(:disabled)");
+    let submitBtn = $('form#suggest-aid-modal-form button[type=submit]');
+    let checkboxesEnabled = $("#from-group-favorite-projects input[type='checkbox']:not(:disabled)");
 
     submitBtn.prop('disabled', true);
     checkboxesEnabled.each(function(index) {

--- a/src/static/js/aids/favorite_project_checkbox_required.js
+++ b/src/static/js/aids/favorite_project_checkbox_required.js
@@ -1,0 +1,16 @@
+$(document).ready(function () {
+    // Disable submit button until at least one enabled checkbox was checked
+    var submitBtn = $('form#suggest-aid-modal-form button[type=submit]');
+    var checkboxesEnabled = $(".fr-form-group input[type='checkbox']:not(:disabled)");
+
+    submitBtn.prop('disabled', true);
+    checkboxesEnabled.each(function(index) {
+    	$(this).on('click', function() {
+			if($(".fr-form-group input[type='checkbox']:checked:not(:disabled)").length) {
+    			submitBtn.prop('disabled', false);
+			} else {
+    			submitBtn.prop('disabled', true);
+			}
+		})
+    });
+});

--- a/src/static/js/aids/favorite_project_checkbox_required.js
+++ b/src/static/js/aids/favorite_project_checkbox_required.js
@@ -6,7 +6,7 @@ $(document).ready(function () {
     submitBtn.prop('disabled', true);
     checkboxesEnabled.each(function(index) {
     	$(this).on('click', function() {
-			if($(".fr-form-group input[type='checkbox']:checked:not(:disabled)").length) {
+			if($("#form-group-favorite-projects input[type='checkbox']:checked:not(:disabled)").length) {
     			submitBtn.prop('disabled', false);
 			} else {
     			submitBtn.prop('disabled', true);

--- a/src/static/js/aids/favorite_project_checkbox_required.js
+++ b/src/static/js/aids/favorite_project_checkbox_required.js
@@ -1,7 +1,7 @@
 $(document).ready(function () {
     // Disable submit button until at least one enabled checkbox was checked
     let submitBtn = $('form#suggest-aid-modal-form button[type=submit]');
-    let checkboxesEnabled = $("#from-group-favorite-projects input[type='checkbox']:not(:disabled)");
+    let checkboxesEnabled = $("#form-group-favorite-projects input[type='checkbox']:not(:disabled)");
 
     submitBtn.prop('disabled', true);
     checkboxesEnabled.each(function(index) {

--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -620,6 +620,7 @@
 </script>
 {% compress js %}
 <script src="{% static 'js/aids/track_aid_events.js' %}"></script>
+<script src="{% static 'js/aids/favorite_project_checkbox_required.js' %}"></script>
 <script src="{% static 'js/alerts/track_alert_button_events.js' %}"></script>
 <script src="{% static 'js/alerts/alert_form.js' %}"></script>
 <script src="{% static 'js/eligibility/eligibility_test_form.js' %}"></script>

--- a/src/templates/projects/_suggest_aid_modal.html
+++ b/src/templates/projects/_suggest_aid_modal.html
@@ -22,7 +22,7 @@
                                 {% if aid_detail_page %}
                                     {% if favorite_projects %}
                                     <div class="fr-form-group">
-                                        <fieldset class="fr-fieldset" id="from-group-favorite-projects">
+                                        <fieldset class="fr-fieldset" id="form-group-favorite-projects">
                                             <legend class="fr-fieldset__legend fr-text--regular" id='checkboxes-legend'>
                                                 Liste des vos projets favoris
                                                 <span class="fr-hint-text">

--- a/src/templates/projects/_suggest_aid_modal.html
+++ b/src/templates/projects/_suggest_aid_modal.html
@@ -15,7 +15,7 @@
                         Vous pouvez désormais suggérer une aide présente sur <a href="{% url 'general_search' %}" target="_blank" rel="noopener" title="Trouver des aides - ouvre une nouvelle fenêtre">Aides-territoires</a>{% if aid_detail_page %}.{% else %} pour ce projet.{% endif %}
                         </p>
                         {% if user.is_authenticated %}
-                        <form id="suggest-aid-modal" method="post" action="{% url 'suggest_aid_view' %}">
+                        <form id="suggest-aid-modal-form" method="post" action="{% url 'suggest_aid_view' %}">
                             <div class="content">
                                 {% csrf_token %}
 
@@ -25,10 +25,13 @@
                                         <fieldset class="fr-fieldset">
                                             <legend class="fr-fieldset__legend fr-text--regular" id='checkboxes-legend'>
                                                 Liste des vos projets favoris
+                                                <span class="fr-hint-text">
+                                                Cochez au moins un projet favori dans la liste pour suggérer cette aide.
+                                                </span>
                                             </legend>
                                             <div class="fr-fieldset__content">
                                                 {% for project in favorite_projects %}
-                                                {% if project in aid.suggested_projects.all %}
+                                                {% if project in aid.suggested_projects.all or project in aid.projects.all %}
                                                 <div class="fr-checkbox-group">
                                                     <input checked disabled type="checkbox" id="{{ project.pk }}" name="project" value="{{ project.pk }}">
                                                     <label class="fr-label" for="{{ project.pk }}">{{ project.name }}

--- a/src/templates/projects/_suggest_aid_modal.html
+++ b/src/templates/projects/_suggest_aid_modal.html
@@ -22,7 +22,7 @@
                                 {% if aid_detail_page %}
                                     {% if favorite_projects %}
                                     <div class="fr-form-group">
-                                        <fieldset class="fr-fieldset">
+                                        <fieldset class="fr-fieldset" id="from-group-favorite-projects">
                                             <legend class="fr-fieldset__legend fr-text--regular" id='checkboxes-legend'>
                                                 Liste des vos projets favoris
                                                 <span class="fr-hint-text">


### PR DESCRIPTION
- Ajout d'une condition pour vérifier que l'aide à suggérer n'est pas déjà associée au projet avant la soumission du formulaire
- Ajout d'une condition : au moins un projet favori doit être sélectionné avant soumission du formulaire