### PR TITLE
Affichage données département + échelle en pourcents

### DIFF
--- a/src/static/css/stats.css
+++ b/src/static/css/stats.css
@@ -60,7 +60,7 @@
 
 .legend i {
   width: 18px;
-  height: 18px;
+  height: 14px;
   float: left;
   margin-right: 8px;
   opacity: 0.7;

--- a/src/stats/tests/test_views.py
+++ b/src/stats/tests/test_views.py
@@ -56,21 +56,14 @@ def test_organizations_displayed_by_cartographie(client, superuser, perimeters):
     response = client.get(reverse("carto_stats"))
     assert response.status_code == 200
     assert response.context["regions_org_communes_max"] == 1
-    assert json.loads(response.context["regions_org_communes_count"]) == {
-        "Occitanie": 1,
-        "Normandie": 0,
-        "Nouvelle-Aquitaine": 0,
-        "Corse": 0,
-        "Bourgogne": 0,
+    assert json.loads(response.context["regions_org_counts"]) == {
+        "26": {"communes_count": 0, "epcis_count": 0, "name": "Bourgogne"},
+        "28": {"communes_count": 0, "epcis_count": 0, "name": "Normandie"},
+        "75": {"communes_count": 0, "epcis_count": 0, "name": "Nouvelle-Aquitaine"},
+        "76": {"communes_count": 1, "epcis_count": 1, "name": "Occitanie"},
+        "94": {"communes_count": 0, "epcis_count": 0, "name": "Corse"},
     }
-    assert json.loads(response.context["regions_org_epcis_count"]) == {
-        "Occitanie": 1,
-        "Normandie": 0,
-        "Nouvelle-Aquitaine": 0,
-        "Corse": 0,
-        "Bourgogne": 0,
-    }
-    assert response.context["departments_org_communes_max"] == 1
+    assert response.context["departments_org_communes_max"] == "30"
     assert response.context["departments_codes"] == [
         "12",
         "19",
@@ -80,23 +73,49 @@ def test_organizations_displayed_by_cartographie(client, superuser, perimeters):
         "28",
         "34",
     ]
-    assert json.loads(response.context["departments_org_communes_count"]) == {
-        "Hérault": 1,
-        "Aveyron": 0,
-        "Eure": 0,
-        "Corrèze": 0,
-        "Corse-du-Sud": 0,
-        "Haute-Corse": 0,
-        "Côte-d’Or": 0,
-    }
-    assert json.loads(response.context["departments_org_epcis_count"]) == {
-        "Hérault": 1,
-        "Aveyron": 0,
-        "Eure": 0,
-        "Corrèze": 0,
-        "Corse-du-Sud": 0,
-        "Haute-Corse": 0,
-        "Côte-d’Or": 0,
+    assert json.loads(response.context["departments_org_counts"]) == {
+        "12": {
+            "communes_count": 0,
+            "epcis_count": 0,
+            "name": "Aveyron",
+            "percentage_communes": 0.0,
+        },
+        "19": {
+            "communes_count": 0,
+            "epcis_count": 0,
+            "name": "Corrèze",
+            "percentage_communes": 0.0,
+        },
+        "21": {
+            "communes_count": 0,
+            "epcis_count": 0,
+            "name": "Côte-d’Or",
+            "percentage_communes": 0.0,
+        },
+        "28": {
+            "communes_count": 0,
+            "epcis_count": 0,
+            "name": "Eure",
+            "percentage_communes": 0.0,
+        },
+        "2A": {
+            "communes_count": 0,
+            "epcis_count": 0,
+            "name": "Corse-du-Sud",
+            "percentage_communes": 0.0,
+        },
+        "2B": {
+            "communes_count": 0,
+            "epcis_count": 0,
+            "name": "Haute-Corse",
+            "percentage_communes": 0.0,
+        },
+        "34": {
+            "communes_count": 1,
+            "epcis_count": 1,
+            "name": "Hérault",
+            "percentage_communes": 0.3,
+        },
     }
 
     communes_with_org = json.loads(response.context["communes_with_org"])

--- a/src/stats/views.py
+++ b/src/stats/views.py
@@ -28,7 +28,17 @@ from stats.forms import StatSearchForm
 from accounts.mixins import SuperUserRequiredMixin
 from aids.views import AidPaginator
 
-# Source: https://fr.wikipedia.org/wiki/Nombre_de_communes_en_France
+# The manual percentage threshold to ensure that the metropolitan area
+# has enough contrasts between departments. It is not computed because
+# some exceptions like Guadeloupe already have 70% of their communes
+# with an account!
+DEPARTMENTS_ORG_COMMUNES_MAX = "30"
+
+# That table should/could be computed with the `populate_communes`
+# command once and for all, annualy from official sources (COG or geoAPI).
+# For instance the length of:
+# https://geo.api.gouv.fr/communes?fields=nom&codeDepartement=54
+# Current source: https://fr.wikipedia.org/wiki/Nombre_de_communes_en_France
 NB_COMMUNES_PAR_DEPARTEMENT_2022 = {
     "01": 393,
     "02": 799,
@@ -528,7 +538,7 @@ class CartoStatsView(SuperUserRequiredMixin, TemplateView):
         # percentage and are hiding small differences across metropolitan
         # departments…
         # Once homogenized, it is possible to use the logic for regions here.
-        context["departments_org_communes_max"] = "30"
+        context["departments_org_communes_max"] = DEPARTMENTS_ORG_COMMUNES_MAX
         context["departments_org_counts"] = json.dumps(
             departments_org_counts, cls=DjangoJSONEncoder
         )

--- a/src/templates/stats/carto_stats.html
+++ b/src/templates/stats/carto_stats.html
@@ -86,17 +86,11 @@
       <script data-map-target="regions" type="application/json" nonce="{{ request.csp_nonce }}">
         {{ regions_geojson|safe }}
       </script>
-      <script data-map-target="regionsOrgCommunesCount" type="application/json" nonce="{{ request.csp_nonce }}">
-        {{ regions_org_communes_count|safe }}
+      <script data-map-target="regionsOrgCounts" type="application/json" nonce="{{ request.csp_nonce }}">
+        {{ regions_org_counts|safe }}
       </script>
-      <script data-map-target="regionsOrgEpcisCount" type="application/json" nonce="{{ request.csp_nonce }}">
-        {{ regions_org_epcis_count|safe }}
-      </script>
-      <script data-map-target="departmentsOrgCommunesCount" type="application/json" nonce="{{ request.csp_nonce }}">
-        {{ departments_org_communes_count|safe }}
-      </script>
-      <script data-map-target="departmentsOrgEpcisCount" type="application/json" nonce="{{ request.csp_nonce }}">
-        {{ departments_org_epcis_count|safe }}
+      <script data-map-target="departmentsOrgCounts" type="application/json" nonce="{{ request.csp_nonce }}">
+        {{ departments_org_counts|safe }}
       </script>
       <script data-map-target="communesWithOrg" type="application/json" nonce="{{ request.csp_nonce }}">
         {{ communes_with_org|safe }}


### PR DESCRIPTION
1. Affichage du nombre de communes/epcis ayant un compte par département lorsqu’on est à l’échelle de la commune
2. Utilisation d’une échelle de couleurs basée sur le pourcentage de communes ayant un compte par département (et affichage de ce pourcentage)
3. Passage du noir au violet pour les communes ayant potentiellement une incohérence
4. Réduction d’un bug CSS sur l’affichage de la légende