### PR TITLE
Réparation de petits bugs sur la fonctionnalité de publication des projets

### DIFF
--- a/src/projects/admin.py
+++ b/src/projects/admin.py
@@ -50,6 +50,10 @@ class ProjectAdmin(ImportExportActionModelAdmin):
     readonly_fields = ["date_created", "nb_aids_associated", "display_related_aids"]
     autocomplete_fields = ["organizations", "author", "project_types"]
 
+    def view_on_site(self, obj):
+        url = reverse('public_project_detail_view', kwargs={'pk': obj.pk, 'slug': obj.slug})
+        return url
+
     def display_related_aids(self, obj):
         related_aid_html = format_html(
             "<table> \

--- a/src/projects/forms.py
+++ b/src/projects/forms.py
@@ -66,6 +66,7 @@ class ProjectCreateForm(forms.ModelForm, AidesTerrBaseForm):
     )
     contract_link = forms.ChoiceField(
         label="Appartenance à un plan/programme/contrat",
+        choices=Project.CONTRACT_LINK,
         required=False,
     )
     is_public = forms.BooleanField(

--- a/src/projects/views.py
+++ b/src/projects/views.py
@@ -240,7 +240,10 @@ class PublicProjectDetailView(DetailView):
         try:
             obj = queryset.get()
             if obj.is_public is False or obj.status != Project.STATUS.published:
-                raise PermissionDenied()
+                if self.request.user.is_authenticated and self.request.user.is_superuser:
+                    return obj
+                else:
+                    raise PermissionDenied()
         except queryset.model.DoesNotExist:
             raise Http404()
         return obj

--- a/src/templates/projects/public_project_detail.html
+++ b/src/templates/projects/public_project_detail.html
@@ -44,6 +44,14 @@
 
 {% block content %}
 <div class="fr-container fr-mb-5w fr-mt-0">
+
+    {% if project.status == 'reviewable' and user.is_superuser %}
+    <div class="fr-alert fr-alert--warning at-clear fr-my-2w">
+        <p class="fr-alert__title">Attention ! Ce projet n’est actuellement pas affiché sur le site.</p>
+        <p>Vous pouvez le prévisualiser parce que vous en êtes le modérateur.</p>
+    </div>
+    {% endif %}
+
     <div class="fr-grid-row">
 
         <div class="fr-col-12">


### PR DESCRIPTION
Bug : réparer le formulaire de création de projet (champ appartenance à un plan/programme/contrat)
Bug : Autoriser les superuser à prévisualiser les projets publics dont le statut est en revu depuis le bouton 'voir sur le site' de django-admin
https://www.notion.so/Probl-me-de-pr-visualisation-des-projets-publics-3d7d65d548094367abbb33f55b98b3dd
https://www.notion.so/Bug-lors-de-la-s-lection-des-plans-programmes-contrats-lorsque-l-utilisateur-cr-e-un-projet-bcb88fcdc75a4cc1bcc12dfc63acddbf