### PR TITLE
Réparer le champ de recherche "votre territoire" sur la page d'accueil

### DIFF
--- a/src/projects/forms.py
+++ b/src/projects/forms.py
@@ -272,7 +272,7 @@ class ProjectSearchForm(AidesTerrBaseForm):
         choices=ORGANIZATION_TYPE_CHOICES_COMMUNES_OR_EPCI,
     )
 
-    perimeter = AutocompleteModelChoiceField(
+    project_perimeter = AutocompleteModelChoiceField(
         queryset=Perimeter.objects.all(), label="Territoire du projet", required=False
     )
 
@@ -315,9 +315,9 @@ class ProjectSearchForm(AidesTerrBaseForm):
         if contract_link:
             qs = qs.filter(contract_link=contract_link)
 
-        perimeter = self.cleaned_data.get("perimeter", None)
-        if perimeter:
-            qs = self.perimeter_filter(qs, perimeter)
+        project_perimeter = self.cleaned_data.get("project_perimeter", None)
+        if project_perimeter:
+            qs = self.perimeter_filter(qs, project_perimeter)
 
         project_types = self.cleaned_data.get("project_types", None)
         if project_types:

--- a/src/static/js/aids/project_perimeter_autocomplete.js
+++ b/src/static/js/aids/project_perimeter_autocomplete.js
@@ -1,0 +1,50 @@
+$(document).ready(function () {
+    // hide "custom" perimeters in the user part of the website
+    let RESTRICT_TO_VISIBLE_PERIMETERS = $('#project_perimeter').length || $('#perimeter').length || $('#search-form').length || $('#advanced-search-form').length || $('#register-page').length || $('#register-commune-page').length;
+    let RESTRICT_TO_NON_OBSOLETE_PERIMETERS = $('#project_perimeter').length || $('#perimeter').length || $('#search-form').length || $('#advanced-search-form').length || $('#register-page').length || $('#register-commune-page').length;
+
+    // Filter on scale on certain forms
+    let scale = null;
+    let RESTRICT_TO_COMMUNES = $('#register-commune-page').length
+    if (RESTRICT_TO_COMMUNES) {
+        scale = 'commune';
+    }
+
+    $('select#id_project_perimeter').select2({
+        placeholder: "Tous les territoires",
+        allowClear: true,
+        minimumInputLength: 1,
+        language: {
+            inputTooShort: function () { return ''; },
+        },
+        ajax: {
+            url: catalog.perimeter_url,
+            dataType: 'json',
+            delay: 100,
+            data: function (params) {
+                let query = {
+                    q: params.term,
+                    is_visible_to_users: RESTRICT_TO_VISIBLE_PERIMETERS ? true : false,
+                    is_non_obsolete: RESTRICT_TO_NON_OBSOLETE_PERIMETERS ? true : false,
+                }
+                if (scale) {
+                    query.scale = scale;
+                }
+                return query;
+            },
+            processResults: function (data, params) {
+                params.page = params.page || 1;
+
+                return {
+                    results: data.results,
+                    pagination: {
+                        more: data.next != null
+                    }
+                };
+            },
+        },
+        theme: "select2-dsfr",
+        dropdownAutoWidth: true,
+        width: "auto",
+    });
+});

--- a/src/templates/home/home.html
+++ b/src/templates/home/home.html
@@ -263,6 +263,7 @@
         <script src="{% static 'js/aids/aid_types_autocomplete.js' %}"></script>
         <script src="{% static 'js/aids/categories_autocomplete.js' %}"></script>
         <script src="{% static 'js/aids/perimeter_autocomplete.js' %}"></script>
+        <script src="{% static 'js/aids/project_perimeter_autocomplete.js' %}"></script>
         <script src="{% static 'js/aids/backers_autocomplete.js' %}"></script>
         <script src="{% static 'js/aids/text_autocomplete.js' %}"></script>
         <script src="{% static 'js/projects/project_types_autocomplete.js' %}"></script>

--- a/src/templates/projects/_project_search_form.html
+++ b/src/templates/projects/_project_search_form.html
@@ -5,7 +5,7 @@
             {% block form-body %}
                 <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center">
                     <div class="fr-col-12 fr-col-md-3">
-                        {% include '_field_snippet.html' with field=form.perimeter %}
+                        {% include '_field_snippet.html' with field=form.project_perimeter %}
                     </div>
 
                     <div class="fr-col-12 fr-col-md-3">

--- a/src/templates/projects/public_projects_list.html
+++ b/src/templates/projects/public_projects_list.html
@@ -100,7 +100,7 @@
     {% compress js %}
         <script src="{% static 'select2/dist/js/select2.js' %}"></script>
         <script src="{% static 'select2/dist/js/i18n/fr.js' %}"></script>
-        <script src="{% static 'js/aids/perimeter_autocomplete.js' %}"></script>
+        <script src="{% static 'js/aids/project_perimeter_autocomplete.js' %}"></script>
         <script src="{% static 'js/projects/project_types_autocomplete.js' %}"></script>
         <script src="{% static 'js/aids/select2_dsfr.js' %}"></script>
         <script src="{% static 'js/url_parameters.js' %}"></script>


### PR DESCRIPTION
Suite à l'implémentation du formulaire de recherches de projets sur l'accueil, le champ territoire du formulaire de recherche d'aides, également sur la page d'accueil était cassé. réparation en renommant le champ `perimeter` du formulaire de recherche de projets afin qu'il n'est pas le même nom que le champ présent pour la recherche d'aides. 