### PR TITLE
Filter out superusers and Aid’s author from stats

### DIFF
--- a/src/aids/api/views.py
+++ b/src/aids/api/views.py
@@ -164,6 +164,10 @@ class AidViewSet(
 
         # Fetching only 1 aid --> AidViewEvent
         if self.detail:
+            # TODO: set the is_live parameter but it requires to retrieve
+            # the object, maybe we can get it from the request/response?
+            # Also, it might be pertinent to filter out queries from
+            # superusers and Aid’s author but is that a real case scenario??
             if response.data.get("id"):
                 log_aidviewevent.delay(
                     aid_id=response.data.get("id"),

--- a/src/aids/views.py
+++ b/src/aids/views.py
@@ -537,7 +537,11 @@ class AidDetailView(DetailView):
     def get(self, request, *args, **kwargs):
         response = super().get(request, *args, **kwargs)
 
-        if self.object.is_published():
+        if (
+            self.object.is_published()
+            and not request.user.is_superuser()
+            and request.user != self.object.author
+        ):
             current_search = response.context_data.get("current_search", "")
             host = request.get_host()
             request_ua = request.META.get("HTTP_USER_AGENT", "")
@@ -548,6 +552,7 @@ class AidDetailView(DetailView):
                 source=host,
                 request_ua=request_ua,
                 request_referer=request_referer,
+                is_live=self.object.is_live(),
             )
 
         return response

--- a/src/stats/models.py
+++ b/src/stats/models.py
@@ -8,6 +8,7 @@ from aids.models import Aid
 
 class AidViewEvent(models.Model):
     aid = models.ForeignKey("aids.Aid", verbose_name=_("Aid"), on_delete=models.PROTECT)
+    aid_live = models.BooleanField(_("Aid was live at the moment of the hit/view"))
 
     targeted_audiences = ChoiceArrayField(
         verbose_name=_("Targeted audiences"),

--- a/src/stats/utils.py
+++ b/src/stats/utils.py
@@ -21,7 +21,7 @@ crawler_detect = CrawlerDetect()
 
 @app.task
 def log_aidviewevent(
-    aid_id, querystring="", source="", request_ua="", request_referer=""
+    aid_id, querystring="", source="", request_ua="", request_referer="", is_live=True
 ):
     source_cleaned = get_site_from_host(source)
     querystring_cleaned = clean_search_querystring(querystring)
@@ -40,6 +40,7 @@ def log_aidviewevent(
 
         AidViewEvent.objects.create(
             aid_id=aid_id,
+            aid_live=is_live,
             targeted_audiences=targeted_audiences,
             querystring=querystring_cleaned,
             source=source_cleaned,


### PR DESCRIPTION
Cette PR est un embryon pour ne pas oublier de filtrer le recueil des statistiques de vues actuelles.

Je ne suis pas sûr d'avoir/prendre le temps de le faire sur les crédits qu'il me reste.