### PR TITLE
Projets public : Envoi d’emails dans le cadre de la fonctionnalité de suggestion d'aide

### DIFF
--- a/src/accounts/tasks.py
+++ b/src/accounts/tasks.py
@@ -315,6 +315,8 @@ def send_new_suggested_aid_notification_email(
         return
 
     suggested_aid = Aid.objects.get(id=suggested_aid_id)
+    suggested_aid_financer_name = suggested_aid.financers.first().name
+    suggested_aid_reccurence = suggested_aid.get_recurrence_display()
     project = Project.objects.get(id=project_id)
     base_url = get_base_url()
     reverse_account_url = reverse("user_dashboard")
@@ -333,6 +335,8 @@ def send_new_suggested_aid_notification_email(
             "suggester_organization_name": suggester_organization_name,
             "project_name": project.name,
             "suggested_aid_name": suggested_aid.name,
+            "suggested_aid_financer_name": suggested_aid_financer_name,
+            "suggested_aid_reccurence": suggested_aid_reccurence,
             "full_account_url": full_account_url,
             "full_project_url": full_project_url,
         },

--- a/src/templates/emails/new_suggested_aid.txt
+++ b/src/templates/emails/new_suggested_aid.txt
@@ -1,0 +1,20 @@
+{% load settings %}
+
+Bonjour {{ project_author_name }}, 
+
+{{ suggester_user_name }} de "{{ suggester_organization_name }}" vous a suggéré l’aide suivante pour financer ou accompagner votre projet "{{project_name}}" sur Aides-territoires : 
+
+"{{ suggested_aid_name }}"
+
+Cette aide vous semble pertinente ? Ajoutez-la à votre projet: {{ full_project_url }}
+
+Pour cela, rendez-vous sur votre compte: {{ full_account_url }} 
+
+- Dans le menu "Gérer mes projets"
+- Sélectionnez votre projet "{{ project_name }}"
+- Retrouvez cette aide dans le tableau “Liste des aides suggérées” tout en bas de l’écran
+- Dans la colonne “Action”, cliquez sur les boutons ✅ ou ❌ si vous souhaitez ou non associer l’aide qui vous a été suggérée à votre projet.
+
+À très vite !
+
+L'équipe d'Aides-territoires

--- a/src/templates/emails/new_suggested_aid.txt
+++ b/src/templates/emails/new_suggested_aid.txt
@@ -4,7 +4,9 @@ Bonjour {{ project_author_name }},
 
 {{ suggester_user_name }} de "{{ suggester_organization_name }}" vous a suggéré l’aide suivante pour financer ou accompagner votre projet "{{project_name}}" sur Aides-territoires : 
 
-"{{ suggested_aid_name }}"
+Titre de l’aide : "{{ suggested_aid_name }}"
+Porteur de l'aide : "{{ suggested_aid_financer_name }}"
+Type d'aide : {{ suggested_aid_reccurence }}
 
 Cette aide vous semble pertinente ? Ajoutez-la à votre projet: {{ full_project_url }}
 


### PR DESCRIPTION
https://www.notion.so/Ouverture-des-projets-v3-envoi-d-un-email-au-porteur-d-un-projet-l-informant-qu-une-nouvelle-aide--e1cb424e762545db89968d9dd755fc65