### PR TITLE
Réparation de l'outil de détection des aides en doublon dans le formulaire de contribution

### DIFF
--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -353,12 +353,14 @@ class AidEditForm(BaseAidForm):
         required=False,
         help_text="Sélectionnez la ou les thématiques associées à votre aide. N’hésitez pas à en choisir plusieurs.",  # noqa
     )
+    slug = forms.CharField(widget=forms.HiddenInput, required=False)
 
     class Meta:
         model = Aid
         fields = [
             "name",
             "name_initial",
+            "slug",
             "short_title",
             "description",
             "categories",

--- a/src/aids/tests/conftest.py
+++ b/src/aids/tests/conftest.py
@@ -8,6 +8,7 @@ def aid_form_data(user, backer, perimeter, category):
 
     return {
         "name": "Test aid",
+        "slug": "",
         "author": user.id,
         "financers": [backer.id],
         "description": "My aid description",

--- a/src/aids/tests/test_workflows.py
+++ b/src/aids/tests/test_workflows.py
@@ -135,6 +135,7 @@ def test_aid_edition_view(client, contributor, aid_form_data):
     assert aids.count() == 1
 
     aid_form_data["name"] = "New title"
+    aid_form_data["slug"] = aid.slug
     res = client.post(form_url, data=aid_form_data)
     assert res.status_code == 302
     assert aids.count() == 1
@@ -156,6 +157,7 @@ def test_draft_aids_can_stay_invalid(client, contributor, aid_form_data):
     assert aids[0].status == "draft"
 
     aid_form_data["description"] = ""
+    aid_form_data["slug"] = aid.slug
     res = client.post(form_url, data=aid_form_data)
     assert res.status_code == 302
     assert aids.count() == 1
@@ -176,6 +178,7 @@ def test_reviewable_aids_cannot_become_invalid(client, contributor, aid_form_dat
     assert aids[0].status == "reviewable"
 
     aid_form_data["description"] = ""
+    aid_form_data["slug"] = aid.slug
     res = client.post(form_url, data=aid_form_data)
     assert res.status_code == 200
     assert aids.count() == 1
@@ -196,6 +199,7 @@ def test_published_aids_cannot_become_invalid(client, contributor, aid_form_data
     assert aids[0].status == "published"
 
     aid_form_data["description"] = ""
+    aid_form_data["slug"] = aid.slug
     res = client.post(form_url, data=aid_form_data)
     assert res.status_code == 200
     assert aids.count() == 1
@@ -262,6 +266,7 @@ def test_aid_status_workflow(client, contributor, aid_form_data):
     client.force_login(contributor)
     form_url = reverse("aid_edit_view", args=[aid.slug])
     aid_form_data.update({"_action": "update_status"})
+    aid_form_data["slug"] = aid.slug
 
     res = client.post(form_url, data=aid_form_data)
     aid.refresh_from_db()
@@ -297,6 +302,7 @@ def test_invalid_aids_cannot_be_in_review(client, contributor, aid_form_data):
     assert aids[0].status == "draft"
 
     aid_form_data.update({"description": "", "_action": "update_status"})
+    aid_form_data["slug"] = aid.slug
     res = client.post(form_url, data=aid_form_data)
     assert res.status_code == 200
     assert aids.count() == 1
@@ -318,6 +324,7 @@ def test_invalid_aids_can_be_unpublished(client, contributor, aid_form_data):
     assert aids[0].status == "published"
 
     aid_form_data.update({"description": "", "_action": "update_status"})
+    aid_form_data["slug"] = aid.slug
     res = client.post(form_url, data=aid_form_data)
     assert res.status_code == 302
     assert aids.count() == 1

--- a/src/static/js/aids/duplicate_buster.js
+++ b/src/static/js/aids/duplicate_buster.js
@@ -70,7 +70,7 @@
         var maxResults = Math.min(count, MAX_RESULTS);
         var duplicates = apiData['results']
             .filter(function (result) {
-                return result['slug'] != currentSlug;
+                return result['slug'] !== currentSlug;
             })
             .slice(0, maxResults)
             .map(formatSingleDuplicate);
@@ -123,7 +123,7 @@
         var currentSlug = slugField.val();
 
         // Be careful as to not count the current aid as a duplicate of itself
-        if (count == 0 || count == 1 && results[0]['slug'] == currentSlug) {
+        if (count === 0 || count === 1 && results[0]['slug'] === currentSlug) {
             topErrorDiv.html('');
             inlineErrorDiv.html('');
         } else {


### PR DESCRIPTION
https://www.notion.so/BUG-Formulaire-de-contribution-l-outil-signale-des-doublons-qui-n-en-sont-pas-8945b5567380488ea114e58353173d4d

L'outil de détection des aides en doublon depuis le formulaire de contribution en front été cassé : Une aide était considérée comme son propre doublon car le champ slug du formulaire (censé permettre une comparaison entre l'aide éditée et celle de la base ayant le même origin_url) avait disparu du form. Je le remets comme hiddeninput.