### PR TITLE
Fix : contrôle de l'ajout du span sr-only au tag a depuis l'admin

### DIFF
--- a/src/dataproviders/utils.py
+++ b/src/dataproviders/utils.py
@@ -113,8 +113,8 @@ def content_prettify(
                         target_warning = soup.new_tag("span")
                         target_warning.attrs = {"class": "fr-sr-only"}
                         target_warning.string = "Ouvre une nouvelle fenêtre"
-
-                        tag.append(target_warning)
+                        if "Ouvre une nouvelle fenêtre" not in tag.text:
+                            tag.append(target_warning)
 
             # Some tags are not allowed, but we do not want to remove
             # their content.
@@ -211,5 +211,7 @@ def mapping_categories_label(
         csvreader = csv.DictReader(csv_file, delimiter=",")
         for index, row in enumerate(csvreader):
             if row[source_column_label]:
-                categories_label_dict[row[source_column_name]] = row[source_column_label]
+                categories_label_dict[row[source_column_name]] = row[
+                    source_column_label
+                ]
     return categories_label_dict


### PR DESCRIPTION
Fix : l'ajout du span sr-only au tag a depuis l'admin ne vérifiait pas si ce span existait déjà.
https://www.notion.so/BUG-Contenus-suite-un-lien-hypertexte-l-outil-inscrit-automatiquement-Ouvre-une-nouvelle-fen-t-cb8d2007f97843f797521bde6fae98c9