### PR TITLE
API : Ajout du champ 'code' à l'endpoint Perimeters

### DIFF
--- a/src/geofr/api/serializers.py
+++ b/src/geofr/api/serializers.py
@@ -15,7 +15,7 @@ class PerimeterSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Perimeter
-        fields = ("id", "text", "name", "scale", "zipcodes")
+        fields = ("id", "text", "name", "scale", "zipcodes", "code")
 
 
 class PerimeterScaleSerializer(serializers.Serializer):


### PR DESCRIPTION
Le champ "code" qui contient pour les communes le code INSEE n'était pas présent dans l'endpoint Perimeters ce qui complique les requêtes de nos partenaires. 
Ex Thibault Rouveyrol du projet https://lafrancedessolutions.gouv.fr/ : 

> On a un cas d'usage où on va renvoyer l'usager (un maire) sur votre site pour une recherche d'aide déjà filtré sur son territoire et ses thematiques.

> https://aides-territoires.beta.gouv.fr/aides/?targeted_audiences=commune&perimeter=%7B%7D&categories=%7B%7D%22

> Du coup on a besoin des variables perimeter et categories. Pour les categories, on va les recup grace à l'api https://aides-territoires.beta.gouv.fr/api/themes/
> Par contre pour les perimeter, c'est votre id interne qui identifie un territoire. De notre coté, on utilise le code INSEE pour identifier le territoire, donc on doit faire un mapping un peu chiant pour essayer de retrouver à quel id interne ça correspond avec 
> https://aides-territoires.beta.gouv.fr/api/perimeters/?q=lyon&is_visible_to_users=true&is_non_obsolete=true
> 
> sauf qu'on peut avoir plusieurs resultats, et du coup c'est pas fiable.
> 
> Ma question : 
> est-ce que vous avez une table de correspondance ID interne -> code insee du territoire ? 
> 