### PR TITLE
Ajouter du texte info sur le champ “territoire” pour accompagner l’utilisateur dans l’inscription 

### DIFF
--- a/src/static/js/aids/perimeter_autocomplete.js
+++ b/src/static/js/aids/perimeter_autocomplete.js
@@ -10,8 +10,15 @@ $(document).ready(function () {
         scale = 'commune';
     }
 
+    // Set the placeholder message
+    let placeholder_message = "Tapez les premiers caractères"
+
+    if ($('#search-form').length || $('#advanced-search-form').length) {
+        placeholder_message = "Tous les territoires"
+    }
+
     $('select#id_perimeter').select2({
-        placeholder: "Tous les territoires",
+        placeholder: placeholder_message,
         allowClear: true,
         minimumInputLength: 1,
         language: {

--- a/src/static/js/aids/project_perimeter_autocomplete.js
+++ b/src/static/js/aids/project_perimeter_autocomplete.js
@@ -10,8 +10,15 @@ $(document).ready(function () {
         scale = 'commune';
     }
 
+    // Set the placeholder message
+    let placeholder_message = "Tapez les premiers caractères"
+
+    if ($('#search-form').length || $('#advanced-search-form').length) {
+        placeholder_message = "Tous les territoires"
+    }
+
     $('select#id_project_perimeter').select2({
-        placeholder: "Tous les territoires",
+        placeholder: placeholder_message,
         allowClear: true,
         minimumInputLength: 1,
         language: {


### PR DESCRIPTION
https://www.notion.so/Ajouter-du-texte-info-sur-le-champ-territoire-pour-accompagner-l-utilisateur-dans-l-inscription-b394775eaf754bf2a073b95223530aef