### PR TITLE
Réparer le tableau “Aides les plus populaires sur la période …” dans l’onglet “engagement” du dashboard stats internes

### DIFF
--- a/src/stats/views.py
+++ b/src/stats/views.py
@@ -586,8 +586,7 @@ class DashboardEngagementView(DashboardBaseView, TemplateView):
                 # the given period, if the range is more that one day. Otherwise,
                 # the `nb_uniq_visitors` key is present in the page result.
                 "nb_uniq_visitors": page.get("nb_uniq_visitors")
-                or page["sum_daily_nb_uniq_visitors"]
-                * (end_date_range - start_date_range).days,
+                or page["sum_daily_nb_uniq_visitors"],
             }
             aid = slugs_aids.get(slug)
             if aid is None:  # Recent aid, not yet in local database.


### PR DESCRIPTION
https://www.notion.so/R-parer-le-tableau-Aides-les-plus-populaires-sur-la-p-riode-dans-l-onglet-engagement-du-dashbo-adc7ddc72d48440fbff785e186574ca6