### PR TITLE
Réparer l’affichage du nombre d’aides sur les pages programmes

### DIFF
--- a/src/templates/programs/detail.html
+++ b/src/templates/programs/detail.html
@@ -68,7 +68,7 @@
                 <h2 class="fr-mt-0 fr-mb-2w">Présentation générale</h2>
                 {{ program.description | safe }}
                 <section id="aid-list">
-                    <h2>{{ aids.count }} aide{% if aids.count > 1 %}s{% endif %} liée{% if aids.count > 1 %}s{% endif %} au programme {{ program.name }}</h2>
+                    <h2>{{ paginator.count }} aide{% if paginator.count > 1 %}s{% endif %} liée{% if paginator.count > 1 %}s{% endif %} au programme {{ program.name }}</h2>
                     {% include 'aids/_search_meta.html' %}
                     {% include "programs/_search_form.html" %}
                     <div class="fr-grid-row">


### PR DESCRIPTION
https://www.notion.so/BUG-R-parer-l-affichage-du-nombre-d-aides-sur-les-pages-programmes-e263c2523c9e4fee88dcc31ed4044401