### PR TITLE
Modifier de la date de mise à jour de la FAQ en cas d’ajout manuel d’une QA sans passer par l’import

### DIFF
--- a/src/templates/programs/_faq_program.html
+++ b/src/templates/programs/_faq_program.html
@@ -4,7 +4,7 @@
         <p class="fr-mb-1w"><strong>Pour tout complément, vous êtes invités à contacter votre sous-préfet d’arrondissement ou les services déconcentrés de l’État compétents (DREAL, DDT-M, directions et services de l’État en outre-mer...).</strong></p>
     </div>
     {% endif %}
-<p class="fr-mb-5 fr-text--sm">Cette FAQ a été mise à jour le {{ faq_questions_answers.first.date_updated|date:'d/m/Y'}}.</p>
+<p class="fr-mb-5 fr-text--sm">Cette FAQ a été mise à jour le {{ faq_questions_answers.last.date_updated|date:'d/m/Y'}}.</p>
 {% else %}
 <div role="alert" class="fr-alert fr-alert--info fr-alert--sm fr-mt-5w fr-mb-5w">
     <p class="fr-mb-1w"><strong>La FAQ est cours de reconstruction, merci de recharger la page dans quelques instants.</strong></p>


### PR DESCRIPTION
https://www.notion.so/modifier-la-date-de-mise-jour-de-la-FAQ-en-ca-d-ajout-manuel-d-une-QA-sans-passer-par-l-import-6484f97e6cdc4238a64773c9ca42a3ca?pvs=4