### PR TITLE
Ajouter un lien vers les pages porteurs sur les pages détail des aides

### DIFF
--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -87,7 +87,12 @@
                     </h2>
                     {% for financer in financers %}
                     <p class="fr-mb-0 fr-ml-1w">
+                        <a href="{% url 'backer_detail_view' financer.pk financer.slug %}"
+                        title="{{ financer.name }} - Ouvrir dans une nouvelle fenêtre"
+                        target="_blank" rel="noopener"
+                        >
                         {{ financer }}
+                        </a>
                     </p>
                     {% endfor %}
                     {% if financers_with_logo %}


### PR DESCRIPTION
https://www.notion.so/Rendre-cliquable-le-nom-du-porteur-d-aide-sur-la-fiche-aide-4aeb4d3371c74beca51ad4c0dd89236c?pvs=4