### PR TITLE
Améliore la fonction json_compare pour gérer les cas où des `{}` existe dans le texte

### DIFF
--- a/src/core/services/json_compare.py
+++ b/src/core/services/json_compare.py
@@ -39,6 +39,8 @@ def json_compare(old_json: JSONField, new_json: JSONField):
         entries = ddiff["values_changed"]
         result_html += format_entries(entries, "added-entries", format_value=True)
 
+    result_html = result_html.replace("{", "(")
+    result_html = result_html.replace("}", ")")
     return format_html(result_html + "</div>")
 
 


### PR DESCRIPTION
https://aides-territoires-beta.sentry.io/issues/4135884081/events/c559d4dd59764109b0fb001fb130148b/?project=5553558&query=is%3Aunresolved&referrer=previous-event&stream_index=0
![Screenshot from 2023-04-28 18-17-14](https://user-images.githubusercontent.com/60744147/235200738-12c58664-9394-4d3d-9409-ededad316ffc.png)
