### PR TITLE
Bug - Retirer le doublon de l’icône calendrier sur les champs de formulaire

### DIFF
--- a/src/templates/_calendar_snippet.html
+++ b/src/templates/_calendar_snippet.html
@@ -1,4 +1,4 @@
-<div class="fr-checkbox-group fr-mb-4w" {% if field.field.required %} required {% endif %}>
+<div class="fr-input-group fr-mb-4w" {% if field.field.required %} required {% endif %}>
     <label for="{{ field.id_for_label }}">
         {{ field.label }}{% if field.field.required %} *{% endif %}
 
@@ -11,7 +11,7 @@
     <div class="{{ nest_field_class }}">
     {% endif %}
 
-    <div class="fr-input-wrap fr-icon-calendar-line">
+    <div class="fr-input-wrap">
         {{ field }}
     </div>
 

--- a/src/templates/stats/_start_end_date_form.html
+++ b/src/templates/stats/_start_end_date_form.html
@@ -1,0 +1,30 @@
+<form method="get" action="{{ form_action }}" class="fr-grid-row fr-grid-row--gutters fr-grid-row--start">
+
+    <div id="form-group-start_date" class="fr-col fr-input-group fr-mb-0">
+      <div class="fr-input-wrap">
+        <label for="id_start_date" class="fr-label"></label>
+        <input type="date" name="start_date" {% if request.GET.start_date %} value="{{ request.GET.start_date }}" {% else %} value="{% now 'Y-m-d' %}" {% endif %} required="" id="id_start_date" class="fr-input fr-mt-0" />
+        <span class="fr-hint-text">Date de début</span>
+      </div>
+    </div>
+
+    <div id="form-group-end_date" class="fr-col fr-input-group fr-mb-0">
+      <div class="fr-input-wrap">
+        <label for="id_end_date" class="fr-label"></label>
+        <input type="date" name="end_date" {% if request.GET.end_date %} value="{{ request.GET.end_date }}" {% else %} value="{% now 'Y-m-d' %}" {% endif %} required="" id="id_end_date" class="fr-input fr-mt-0" />
+        <span class="fr-hint-text">Date de fin</span>
+      </div>
+    </div>
+  
+    <div class="fr-col">
+      <button type="submit" class="fr-btn">Envoyer</button>
+    </div>
+    
+    {% if start_date_error %}
+    <span class="error field-error">
+      ↑
+      {{ start_date_error.0 }}
+      ↑
+    </span>
+    {% endif %}
+  </form>

--- a/src/templates/stats/dashboard_base.html
+++ b/src/templates/stats/dashboard_base.html
@@ -94,36 +94,7 @@
   <div id="statistiques" class="fr-mt-5w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-mb-5w">
     <h2 class="fr-mt-0w">Statistiques sur une période :</h2>
       <div class="fr-col-12 fr-col-md-6 fr-mt-4w">
-        <form method="get" action="." class="fr-grid-row fr-grid-row--start">
-
-          <div id="form-group-start_date" class="fr-input-group fr-mb-0">
-            <div class="fr-input-wrap fr-icon-calendar-line">
-              <label for="id_start_date" class="fr-label"></label>
-              <input type="date" name="start_date" {% if request.GET.start_date %} value="{{ request.GET.start_date }}" {% else %} value="{% now 'Y-m-d' %}" {% endif %} required="" id="id_start_date" class="fr-input fr-mt-0" />
-              <span class="fr-hint-text">Date de début</span>
-            </div>
-          </div>
-
-          <div id="form-group-end_date" class="fr-input-group fr-mb-0">
-            <div class="fr-input-wrap fr-icon-calendar-line">
-              <label for="id_end_date" class="fr-label"></label>
-              <input type="date" name="end_date" {% if request.GET.end_date %} value="{{ request.GET.end_date }}" {% else %} value="{% now 'Y-m-d' %}" {% endif %} required="" id="id_end_date" class="fr-input fr-mt-0" />
-              <span class="fr-hint-text">Date de fin</span>
-            </div>
-          </div>
-        
-          <div>
-            <button type="submit" class="fr-btn">Envoyer</button>
-          </div>
-          
-          {% if start_date_error %}
-          <span class="error field-error">
-            ↑
-            {{ start_date_error.0 }}
-            ↑
-          </span>
-          {% endif %}
-        </form>
+        {% include 'stats/_start_end_date_form.html' with action="." %}
     </div>
   </div>
 

--- a/src/templates/stats/organizations_stats.html
+++ b/src/templates/stats/organizations_stats.html
@@ -57,30 +57,8 @@
     <h4 class="fr-mt-0w">Structures :</h4>
 
     <div class="fr-col-12 fr-col-md-6 fr-mt-4w">
-        <form method="get" action="{% url 'organizations_stats' %}" class="fr-grid-row fr-grid-row--start">
-          <div id="form-group-start_date" class="fr-input-group fr-mb-0">
-            <div class="fr-input-wrap fr-icon-calendar-line">
-                <label for="id_start_date" class="fr-label"></label>
-                <input type="date" name="start_date" {% if request.GET.start_date %} value="{{ request.GET.start_date }}" {% else %} value="{% now 'Y-m-d' %}" {% endif %} required="" id="id_start_date" class="fr-input fr-mt-0" />
-                <span class="fr-hint-text">Date de début</span>
-            </div>
-          </div>
-          <div id="form-group-end_date" class="fr-input-group fr-mb-0">
-            <div class="fr-input-wrap fr-icon-calendar-line">
-                <label for="id_end_date" class="fr-label"></label>
-                <input type="date" name="end_date" {% if request.GET.end_date %} value="{{ request.GET.end_date }}" {% else %} value="{% now 'Y-m-d' %}" {% endif %} required="" id="id_end_date" class="fr-input fr-mt-0" />
-                <span class="fr-hint-text">Date de fin</span>
-            </div>
-          </div>
-          <div>
-                <button type="submit" class="fr-btn">Envoyer</button>
-          </div>
-          {% if start_date_error %}
-            <p id="text-input-error-start-date" class="fr-error-text">
-                {{ start_date_error.0 }}
-            </p>
-          {% endif %}
-        </form>
+        {% url 'organizations_stats' as action_url %}
+        {% include 'stats/_start_end_date_form.html' with action=action_url %}
     </div>
 
     <div class="fr-table at-table--fullwidth fr-table--bordered fr-mt-5w">

--- a/src/templates/stats/projects_stats.html
+++ b/src/templates/stats/projects_stats.html
@@ -30,30 +30,8 @@
     <h1 class="fr-mt-0w fr-h4">Projets :</h1>
 
     <div class="fr-col-12 fr-col-md-6 fr-mt-4w">
-        <form method="get" action="{% url 'projects_stats' %}" class="fr-grid-row fr-grid-row--start">
-          <div id="form-group-start_date" class="fr-input-group fr-mb-0">
-            <div class="fr-input-wrap fr-icon-calendar-line">
-                <label for="id_start_date" class="fr-label"></label>
-                <input type="date" name="start_date" {% if request.GET.start_date %} value="{{ request.GET.start_date }}" {% else %} value="{% now 'Y-m-d' %}" {% endif %} required="" id="id_start_date" class="fr-input fr-mt-0" />
-                <span class="fr-hint-text">Date de début</span>
-            </div>
-          </div>
-          <div id="form-group-end_date" class="fr-input-group fr-mb-0">
-            <div class="fr-input-wrap fr-icon-calendar-line">
-                <label for="id_end_date" class="fr-label"></label>
-                <input type="date" name="end_date" {% if request.GET.end_date %} value="{{ request.GET.end_date }}" {% else %} value="{% now 'Y-m-d' %}" {% endif %} required="" id="id_end_date" class="fr-input fr-mt-0" />
-                <span class="fr-hint-text">Date de fin</span>
-            </div>
-          </div>
-          <div>
-                <button type="submit" class="fr-btn">Envoyer</button>
-          </div>
-          {% if start_date_error %}
-            <p id="text-input-error-start-date" class="fr-error-text">
-                {{ start_date_error.0 }}
-            </p>
-          {% endif %}
-        </form>
+        {% url 'projects_stats' as action_url %}
+        {% include 'stats/_start_end_date_form.html' with action=action_url %}
     </div>
 
     <div class="fr-table fr-table--bordered fr-mt-5w">

--- a/src/templates/stats/users_stats.html
+++ b/src/templates/stats/users_stats.html
@@ -61,7 +61,7 @@
         </table>
     </div>
 
-    <h4 class="fr-mt-0w">Comptes utilisateurs&nbsp;:</h4>
+    <h4 class="fr-mt-0w">Comptes utilisateurs :</h4>
 
     <div class="fr-col-12 fr-col-md-6 fr-mt-4w">
         {% url 'users_stats' as action_url %}

--- a/src/templates/stats/users_stats.html
+++ b/src/templates/stats/users_stats.html
@@ -64,30 +64,8 @@
     <h4 class="fr-mt-0w">Comptes utilisateurs&nbsp;:</h4>
 
     <div class="fr-col-12 fr-col-md-6 fr-mt-4w">
-        <form method="get" action="{% url 'users_stats' %}" class="fr-grid-row fr-grid-row--start">
-          <div id="form-group-start_date" class="fr-input-group fr-mb-0">
-            <div class="fr-input-wrap fr-icon-calendar-line">
-                <label for="id_start_date" class="fr-label"></label>
-                <input type="date" name="start_date" placeholder="jj/mm/aaaa" {% if request.GET.start_date %} value="{{ request.GET.start_date }}" {% else %} value="{% now 'Y-m-d' %}" {% endif %} required="" id="id_start_date" class="fr-input fr-mt-0">
-                <span class="fr-hint-text">Date de début</span>
-            </div>
-          </div>
-          <div id="form-group-end_date" class="fr-input-group fr-mb-0">
-            <div class="fr-input-wrap fr-icon-calendar-line">
-                <label for="id_end_date" class="fr-label"></label>
-                <input type="date" name="end_date" placeholder="jj/mm/aaaa" {% if request.GET.end_date %} value="{{ request.GET.end_date }}" {% else %} value="{% now 'Y-m-d' %}" {% endif %} required="" id="id_end_date" class="fr-input fr-mt-0">
-                <span class="fr-hint-text">Date de fin</span>
-            </div>
-          </div>
-          <div>
-                <button type="submit" class="fr-btn">Envoyer</button>
-          </div>
-          {% if start_date_error %}
-            <p id="text-input-error-start-date" class="fr-error-text">
-                {{ start_date_error.0 }}
-            </p>
-          {% endif %}
-        </form>
+        {% url 'users_stats' as action_url %}
+        {% include 'stats/_start_end_date_form.html' with action=action_url %}
     </div>
 
     <div class="fr-table fr-table--bordered fr-mt-5w">


### PR DESCRIPTION
https://www.notion.so/Bug-Retirer-le-doublon-de-l-ic-ne-calendrier-sur-les-champs-de-formulaire-f319529cfc634dd29bad6eef9fb6246c?pvs=4