### PR TITLE
Répare une erreur lors de l'envoi d'alerte lorsque la source de l'alerte n'est pas définie

### DIFF
--- a/src/alerts/management/commands/send_alerts.py
+++ b/src/alerts/management/commands/send_alerts.py
@@ -85,6 +85,7 @@ class Command(BaseCommand):
         in_minisite = is_subdomain(alert.source)
         if (
             alert.source != "aides-territoires"
+            and alert.source != ""
             and SearchPage.objects.get(slug=alert.source).subdomain_enabled is not True
         ):
             domain_with_subdomain = build_host_with_subdomain(


### PR DESCRIPTION
https://aides-territoires-beta.sentry.io/issues/4233110095/?project=5553558&referrer=slack