### PR TITLE
Ajouter le statut "archivée" dans l'affichage du portefeuille d'aides

### DIFF
--- a/src/templates/aids/draft_list.html
+++ b/src/templates/aids/draft_list.html
@@ -102,7 +102,13 @@
                                     <p class="fr-badge fr-badge--warning fr-badge--sm">Expirée</p>
                                 {% endif %}
                             </td>
-                            <td class="nowrap-cell"><a href="{{ aid.get_absolute_url }}">{{ aid.get_status_display }}</a></td>
+                            <td class="nowrap-cell">
+                                {% if aid.has_expired %}
+                                    <a href="{{ aid.get_absolute_url }}">Archivée</a>
+                                {% else %}
+                                    <a href="{{ aid.get_absolute_url }}">{{ aid.get_status_display }}</a>
+                                {% endif %}
+                            </td>
                             <td><a href="{% url 'aid_detail_stats_view' aid.slug %}?start_date={{aid.date_created|date:'Y-m-d'}}&end_date=2023-05-12">{% get hits_per_aid aid.id 0 %}</a></td>
                             <td>
                                 <a href="{% url 'aid_detail_pdf_export_view' aid.slug %}" title="Télécharger la fiche détail de l’aide en PDF" class="fr-btn fr-icon-download-line fr-btn--tertiary fr-btn--tertiary-no-outline at-box-shadow--none"><span class="fr-sr-only">Télécharger la fiche détail de l’aide en PDF</span></a>


### PR DESCRIPTION
https://www.notion.so/Dans-le-portefeuille-d-aides-du-contributeur-lorsqu-une-aide-est-expir-e-mettre-le-statut-Expir-e-418e72c4b2be4879b465afd1b08e1487?pvs=4