### PR TITLE
Modifier le label pour le champ `mobilization_steps` sur la page détail des aides

### DIFF
--- a/src/templates/aids/detail.html
+++ b/src/templates/aids/detail.html
@@ -453,7 +453,7 @@
 
                 {% if aid.mobilization_steps %}
                 <p class="fr-mb-2w">
-                    <strong>Avancée du projet :</strong>
+                    <strong>État d’avancement du projet pour bénéficier du dispositif :</strong>
                     {% choices_display aid 'mobilization_steps' %}
                 </p>
                 {% endif %}


### PR DESCRIPTION
https://www.notion.so/Sur-les-fiches-aides-remplacer-le-titre-du-champ-Dispositif-applicable-pour-un-projet-par-tat-d-9b0f1afc9713411696b936ec6281944f?pvs=4