### PR TITLE
Rendre obligatoire le champ "type de dépense / action couverte"

### DIFF
--- a/src/aids/forms.py
+++ b/src/aids/forms.py
@@ -261,6 +261,15 @@ class AidAdminForm(BaseAidForm):
                     ValidationError(msg, code="missing_mobilization_steps"),
                 )
 
+            if not data.get("destinations", None):
+                msg = (
+                    "Veuillez compléter le champ types de dépenses / actions couvertes"
+                )
+                self.add_error(
+                    "destinations",
+                    ValidationError(msg, code="missing_destinations"),
+                )
+
             if not data.get("perimeter", None):
                 msg = "Veuillez renseigner une zone géographique."
                 self.add_error(
@@ -438,6 +447,9 @@ class AidEditForm(BaseAidForm):
 
         if "mobilization_steps" in self.fields:
             self.fields["mobilization_steps"].required = True
+
+        if "destinations" in self.fields:
+            self.fields["destinations"].required = True
 
         if "targeted_audiences" in self.fields:
             self.fields["targeted_audiences"].required = True

--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -237,6 +237,7 @@ section#aid-edit {
 #aid-edit #form-group-origin_url .at-field-label::after,
 #aid-edit #form-group-perimeter .at-field-label::after,
 #aid-edit #form-group-recurrence .at-field-label::after,
+#aid-edit #form-group-destinations .at-field-label::after,
 #aid-edit #form-group-targeted_audiences>fieldset>legend .at-field-label::after,
 .at-required--label::after {
   content: '*';


### PR DESCRIPTION
https://www.notion.so/Rendre-obligatoire-le-champs-type-de-d-penses_actions-couvertes-9cfa87b3221a48db83bf239d105158b6?pvs=4