### PR TITLE
Autoriser l'ajout de tableaux dans les contenus rédactionnels

### DIFF
--- a/src/dataproviders/utils.py
+++ b/src/dataproviders/utils.py
@@ -50,6 +50,7 @@ ALLOWED_ATTRS = [
     "allow",
     "frameborder",
     "title",
+    "scope",  # for tables
     "allowfullscreen",  # to display iframe
     "target",
     "aria-hidden",

--- a/src/dataproviders/utils.py
+++ b/src/dataproviders/utils.py
@@ -27,6 +27,12 @@ ALLOWED_TAGS = [
     "h6",
     "br",
     "a",
+    "table",
+    "caption",
+    "tbody",
+    "tr",
+    "td",
+    "th",
     "iframe",
     "figcaption",
     "figure",
@@ -125,6 +131,13 @@ def content_prettify(
                     ]
                 ):
                     tag.decompose()
+
+                if tag.name == "table":
+                    wrapper_attrs = {"class": "fr-table at-table--fullwidth"}
+                    if tag.parent.attrs != wrapper_attrs:
+                        wrapper = soup.new_tag("div")
+                        wrapper.attrs = wrapper_attrs
+                        tag.wrap(wrapper)
 
                 # Replace relative urls with absolute ones
                 if tag.name == "a" and base_url:


### PR DESCRIPTION
https://www.notion.so/Pouvoir-ajouter-des-tableaux-dans-les-champs-textuels-du-formulaire-de-contribution-6b0377069f084d2da2f8ec0b96e9b160?pvs=4