### PR TITLE
Pouvoir identifier sur la page de résultats si on a déjà consulté ou non une aide 

### DIFF
--- a/src/static/css/_custom.scss
+++ b/src/static/css/_custom.scss
@@ -393,6 +393,10 @@ fieldset {
   margin-top: 0.5em;
 }
 
+#aid-list a:visited {
+  color: var(--text-action-high-purple-glycine);
+}
+
 #aid-list .deadline.fr-tag {
   display: block;
   float: right;


### PR DESCRIPTION
https://www.notion.so/Pouvoir-identifier-sur-la-page-de-r-sultats-si-on-a-d-j-consult-ou-non-une-aide-8fcfc8d6b11d4d7da3551e91eab6621a?pvs=4